### PR TITLE
tests(@wallet_settings): add negative scenarios

### DIFF
--- a/constants/wallet.py
+++ b/constants/wallet.py
@@ -11,3 +11,6 @@ class DerivationPath(Enum):
 
 class WalletNetworkSettings(Enum):
     TESTNET_SUBTITLE = 'Switch entire Status app to testnet only mode'
+    TESTNET_ENABLED_TOAST_MESSAGE = 'Testnet mode turned on'
+    TESTNET_DISABLED_TOAST_MESSAGE = 'Testnet mode turned off'
+

--- a/gui/components/wallet/testnet_mode_popup.py
+++ b/gui/components/wallet/testnet_mode_popup.py
@@ -7,20 +7,26 @@ from gui.elements.qt.button import Button
 class TestnetModePopup(BasePopup):
     def __init__(self):
         super(TestnetModePopup, self).__init__()
-        self._cancel_button = Button('add_StatusButton')
+        self._cancel_button = Button('testnet_mode_cancelButton')
+        self._close_cross_button = Button('testnet_mode_closeCrossButton')
         self._turn_on_button = Button('turn_on_testnet_mode_StatusButton')
         self._turn_off_button = Button('turn_off_testnet_mode_StatusButton')
 
-    @allure.step('Choose turn on option')
-    def turn_on_testnet_mode(self):
+    @allure.step('Close testnet mode modal with cross button')
+    def close_testnet_modal_with_cross_button(self):
+        self._close_cross_button.click()
+        self.wait_until_hidden()
+
+    @allure.step('Choose turn on option in the testnet modal')
+    def click_turn_on_testnet_mode_in_testnet_modal(self):
         self._turn_on_button.click()
         self.wait_until_hidden()
 
-    @allure.step('Choose turn off option')
-    def turn_off_testnet_mode(self):
+    @allure.step('Choose turn off option on the testnet modal')
+    def turn_off_testnet_mode_in_testnet_modal(self):
         self._turn_off_button.click()
         self.wait_until_hidden()
 
-    def cancel(self):
+    def click_cancel_button_in_testnet_modal(self):
         self._cancel_button.click()
         self.wait_until_hidden()

--- a/gui/objects_map/component_names.py
+++ b/gui/objects_map/component_names.py
@@ -254,9 +254,10 @@ mainWallet_AddEditAccountPopup_18WordsButton = {"container": mainWallet_AddEditA
 mainWallet_AddEditAccountPopup_24WordsButton = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "24SeedButton", "type": "StatusSwitchTabButton"}
 
 # Testnet mode popup
-turn_on_testnet_mode_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn on testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}
-turn_off_testnet_mode_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn off testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}
-add_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+turn_on_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn on testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}
+turn_off_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn off testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}
+testnet_mode_cancelButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+testnet_mode_closeCrossButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerActionsCloseButton", "type": "StatusFlatRoundButton", "visible": True}
 
 # Testnet mode banner
 mainWindow_testnetBanner_ModuleWarning = {"container": statusDesktop_mainWindow, "objectName": "testnetBanner", "type": "ModuleWarning", "visible": True}

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -362,7 +362,7 @@ class NetworkWalletSettings(WalletSettingsView):
         super(NetworkWalletSettings, self).__init__()
         self._wallet_networks_item = QObject('settingsContentBaseScrollView_WalletNetworkDelegate')
         self._testnet_text_item = QObject('settingsContentBaseScrollView_Goerli_testnet_active_StatusBaseText')
-        self._testnet_mode_button = Button('settings_Wallet_NetworksView_TestNet_Toggle')
+        self._testnet_mode_toggle = Button('settings_Wallet_NetworksView_TestNet_Toggle')
         self._testnet_mode_title = TextLabel('settings_Wallet_NetworksView_TestNet_Toggle_Title')
         self._back_button = Button('main_toolBar_back_button')
 
@@ -376,7 +376,7 @@ class NetworkWalletSettings(WalletSettingsView):
         return self._testnet_mode_title.text
 
     @allure.step('Verify back to Wallet settings button')
-    def is_back_to_wallet__settings_button_present(self):
+    def is_back_to_wallet_settings_button_present(self):
         return self._back_button.is_visible
 
     @property
@@ -388,14 +388,14 @@ class NetworkWalletSettings(WalletSettingsView):
                 items_amount += 1
         return items_amount
 
-    @allure.step('Switch testnet mode')
-    def switch_testnet_mode(self):
-        self._testnet_mode_button.click()
+    @allure.step('Switch testnet mode toggle')
+    def switch_testnet_mode_toggle(self):
+        self._testnet_mode_toggle.click()
         return TestnetModePopup().wait_until_appears()
 
-    @allure.step('Check state of testnet mode switch')
-    def get_testnet_mode_button_checked_state(self):
-        return self._testnet_mode_button.is_checked
+    @allure.step('Get testnet mode toggle status')
+    def get_testnet_mode_toggle_status(self):
+        return self._testnet_mode_toggle.is_checked
 
 
 class EditAccountOrderSettings(WalletSettingsView):


### PR DESCRIPTION
1. Extended verifications for testnet switching toggle functionality:

> 1. having mainnet enabled, toggle the switch -> click cross button in the corresponding confirmation modal -> that should not enable testnets
> 2. having testnets enabled, toggle the switch -> click cancel button in the corresponding confirmation modal -> that should not enable testnets and should keep the toggle state unchanged (bug was opened in desktop repo https://github.com/status-im/status-desktop/issues/12247 and now it is fixed)

2. Added corresponding scenarios to test rail:

> 1. https://ethstatus.testrail.net/index.php?/cases/view/703621
> 2. https://ethstatus.testrail.net/index.php?/cases/view/703622

3. Fixed broken reference for `is_back_to_wallet_settings_button_present()` (my bad)
4. Added assert messages