### PR TITLE
tests(@wallet_settings): edit network

### DIFF
--- a/constants/wallet.py
+++ b/constants/wallet.py
@@ -14,3 +14,19 @@ class WalletNetworkSettings(Enum):
     TESTNET_ENABLED_TOAST_MESSAGE = 'Testnet mode turned on'
     TESTNET_DISABLED_TOAST_MESSAGE = 'Testnet mode turned off'
 
+
+class WalletNetworkNaming(Enum):
+    LAYER1_ETHEREUM = 'Mainnet'
+    LAYER2_OPTIMISIM = 'Optimism'
+    LAYER2_ARBITRUM = 'Arbitrum'
+    ETHEREUM_MAINNET_NETWORK_ID = 1
+    ETHEREUM_GOERLI_NETWORK_ID = 5
+    OPTIMISM_MAINNET_NETWORK_ID = 10
+    OPTIMISM_GOERLI_NETWORK_ID = 420
+    ARBITRUM_MAINNET_NETWORK_ID = 42161
+    ARBITRUM_GOERLI_NETWORK_ID = 421613
+
+
+class WalletNetworkDefaultValues(Enum):
+    ETHEREUM_LIVE_MAIN = 'https://eth-archival.gateway.pokt.network/v1/lb/********'
+    ETHEREUM_LIVE_FAILOVER = 'https://mainnet.infura.io/v3/********************************'

--- a/gui/elements/qt/object.py
+++ b/gui/elements/qt/object.py
@@ -51,6 +51,10 @@ class QObject(BaseObject):
     def width(self) -> int:
         return int(self.bounds.width)
 
+    @allure.step('Get attribute {0}')
+    def get_object_attribute(self, attr: str):
+        return getattr(self.object, attr)
+
     @property
     @allure.step('Get height {0}')
     def height(self) -> int:
@@ -117,7 +121,6 @@ class QObject(BaseObject):
 
         assert driver.waitFor(lambda: _hover(), timeout_msec)
         return self
-
 
     @allure.step('Open context menu')
     def open_context_menu(

--- a/gui/elements/qt/text_edit.py
+++ b/gui/elements/qt/text_edit.py
@@ -30,5 +30,5 @@ class TextEdit(QObject):
         self.object.clear()
         if verify:
             assert driver.waitFor(lambda: not self.text), \
-            f'Clear text field failed, value in field: "{self.text}"'
+                f'Clear text field failed, value in field: "{self.text}"'
         return self

--- a/gui/objects_map/settings_names.py
+++ b/gui/objects_map/settings_names.py
@@ -46,7 +46,6 @@ mainWindow_WalletView = {"container": statusDesktop_mainWindow, "type": "WalletV
 settings_Wallet_MainView_Networks = {"container": statusDesktop_mainWindow, "objectName": "networksItem", "type": "StatusListItem"}
 settings_Wallet_MainView_AddNewAccountButton = {"container": statusDesktop_mainWindow, "objectName": "settings_Wallet_MainView_AddNewAccountButton", "type": "StatusButton", "visible": True}
 settingsContentBaseScrollView_accountOrderItem_StatusListItem = {"container": settingsContentBase_ScrollView, "objectName": "accountOrderItem", "type": "StatusListItem", "visible": True}
-settingsContentBaseScrollView_WalletNetworkDelegate = {"container": settingsContentBase_ScrollView, "type": "WalletNetworkDelegate", "unnamed": 1, "visible": True}
 settingsContentBaseScrollView_StatusListItem = {"container": settingsContentBase_ScrollView, "type": "StatusListItem", "unnamed": 1, "visible": True}
 settings_Wallet_NetworksView_TestNet_Toggle = {"container": statusDesktop_mainWindow, "objectName": "testnetModeSwitch", "type": "StatusSwitch"}
 settings_Wallet_NetworksView_TestNet_Toggle_Title = {"container": settingsContentBase_ScrollView, "objectName": "statusListItemSubTitle", "type": "StatusTextWithLoadingState", "visible": True}
@@ -57,6 +56,30 @@ settingsContentBaseScrollView_accountOrderView_AccountOrderView = {"container": 
 settingsContentBaseScrollView_StatusBaseText = {"container": settingsContentBase_ScrollView, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 mainWindow_StatusToolBar = {"container": statusDesktop_mainWindow, "objectName": "statusToolBar", "type": "StatusToolBar", "visible": True}
 main_toolBar_back_button = {"container": mainWindow_StatusToolBar, "objectName": "toolBarBackButton", "type": "StatusFlatButton", "visible": True}
+settingsContentBaseScrollView_WalletNetworkDelegate_template = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Mainnet_1", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Mainnet = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Mainnet_1", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Mainnet_Goerli = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Mainnet_5", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Optimism = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Optimism_10", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Optimism_Goerli = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Optimism_420", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Arbitrum = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Arbitrum_42161", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Arbitrum_Goerli = {"container": settingsContentBase_ScrollView, "objectName": "walletNetworkDelegate_Arbitrum_421613", "type": "WalletNetworkDelegate", "visible": True}
+networkSettingsNetworks_Mainnet_Goerli_sensor = {"container": networkSettingsNetworks_Mainnet_Goerli, "objectName": "walletNetworkDelegate_Mainnet_5_sensor", "id": "sensor", "type": "MouseArea", "unnamed": 1, "visible": True}
+networkSettingsNetowrks_Mainnet_Testlabel = {"container": networkSettingsNetworks_Mainnet_Goerli_sensor, "objectName": "testnetLabel_Mainnet", "type": "StatusBaseText", "visible": True}
+
+# Wallet edit network view
+settingsContentBaseScrollView_editPreviwTabBar_StatusTabBar = {"container": statusDesktop_mainWindow, "objectName": "editPreviwTabBar", "type": "StatusTabBar"}
+editNetworkLiveButton = {"container": settingsContentBaseScrollView_editPreviwTabBar_StatusTabBar, "objectName": "editNetworkLiveButton", "type": "StatusTabButton"}
+editNetworkTestButton = {"container": settingsContentBaseScrollView_editPreviwTabBar_StatusTabBar, "objectName": "editNetworkTestButton", "type": "StatusTabButton"}
+editNetworkNameInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkNameInput", "type": "TextEdit"}
+editNetworkShortNameInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkShortNameInput", "type": "TextEdit"}
+editNetworkChainIdInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkChainIdInput", "type": "TextEdit"}
+editNetworkSymbolInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkSymbolInput", "type": "TextEdit"}
+editNetworkMainRpcInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkMainRpcInput", "type": "TextEdit", "visible": True}
+editNetworkFailoverRpcUrlInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkFailoverRpcUrlInput", "type": "TextEdit", "visible": True}
+editNetworkExplorerInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkExplorerInput", "type": "TextEdit"}
+editNetworkAknowledgmentCheckbox = {"container": statusDesktop_mainWindow, "objectName": "editNetworkAknowledgmentCheckbox", "type": "StatusCheckBox", "visible": True}
+editNetworkRevertButton = {"container": statusDesktop_mainWindow, "objectName": "editNetworkRevertButton", "type": "StatusButton", "visible": True}
+editNetworkSaveButton = {"container": statusDesktop_mainWindow, "objectName": "editNetworkSaveButton", "type": "StatusButton"}
 
 # Profile View
 mainWindow_MyProfileView = {"container": statusDesktop_mainWindow, "type": "MyProfileView", "unnamed": 1, "visible": True}


### PR DESCRIPTION
Test that user can open network , see its' details , change the values of RPCs and revert them back

Fixes https://github.com/status-im/desktop-qa-automation/issues/136

**NOTE:** i need to handle checking of red error message and later i will enhance the test with some other verifications for components of the screen

https://ethstatus.testrail.net/index.php?/cases/view/703515

<img width="1840" alt="Screenshot 2023-10-04 at 13 49 15" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/03a1e489-3f51-4f97-9aa5-8c461d8f7815">
