### PR TITLE
Negative scenario: wrong sync code

### DIFF
--- a/constants/syncing.py
+++ b/constants/syncing.py
@@ -4,3 +4,4 @@ from enum import Enum
 class SyncingSettings(Enum):
     SYNC_A_NEW_DEVICE_INSTRUCTIONS_HEADER = 'Sync a New Device'
     SYNC_A_NEW_DEVICE_INSTRUCTIONS_SUBTITLE = 'You own your data. Sync it among your devices.'
+    SYNC_CODE_IS_WRONG_TEXT = 'This does not look like a sync code'

--- a/gui/objects_map/onboarding_names.py
+++ b/gui/objects_map/onboarding_names.py
@@ -45,6 +45,7 @@ mainWindow_switchTabBar_StatusSwitchTabBar_2 = {"container": statusDesktop_mainW
 switchTabBar_Enter_sync_code_StatusSwitchTabButton = {"checkable": True, "container": mainWindow_switchTabBar_StatusSwitchTabBar_2, "text": "Enter sync code", "type": "StatusSwitchTabButton", "unnamed": 1, "visible": True}
 mainWindow_statusBaseInput_StatusBaseInput = {"container": statusDesktop_mainWindow, "id": "statusBaseInput", "type": "StatusBaseInput", "unnamed": 1, "visible": True}
 mainWindow_Paste_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow, "text": "Paste", "type": "StatusButton", "unnamed": 1, "visible": True}
+mainWindow_syncingEnterCode_SyncingEnterCode = {"container": mainWindow_StatusWindow, "objectName": "syncingEnterCode", "type": "SyncingEnterCode", "visible": True}
 
 # SyncDevice View
 mainWindow_SyncingDeviceView_found = {"container": statusDesktop_mainWindow, "type": "SyncingDeviceView", "unnamed": 1, "visible": True}

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -127,6 +127,7 @@ class SyncCodeView(OnboardingView):
         super(SyncCodeView, self).__init__('mainWindow_SyncCodeView')
         self._enter_sync_code_button = Button('switchTabBar_Enter_sync_code_StatusSwitchTabButton')
         self._paste_sync_code_button = Button('mainWindow_Paste_StatusButton')
+        self._syncing_enter_code_item = QObject('mainWindow_syncingEnterCode_SyncingEnterCode')
 
     @allure.step('Open enter sync code form')
     def open_enter_sync_code_form(self):
@@ -136,7 +137,11 @@ class SyncCodeView(OnboardingView):
     @allure.step('Paste sync code')
     def paste_sync_code(self):
         self._paste_sync_code_button.click()
-        return SyncDeviceFoundView().wait_until_appears()
+
+    @property
+    @allure.step('Get wrong sync code message')
+    def sync_code_error_message(self) -> str:
+        return self._syncing_enter_code_item.object.syncCodeErrorMessage
 
 
 class SyncDeviceFoundView(OnboardingView):


### PR DESCRIPTION
Added negative scenario for syncing
Changed a bit scenario for syncing during onboarding
https://ethstatus.testrail.net/index.php?/cases/view/703631
<img width="1095" alt="Screenshot 2023-10-05 at 12 11 21" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/98a45fb5-a52d-4194-8b90-177174ab468b">
