### PR TITLE
fix(@wallet_edit_network): adjust to new designs

### DIFF
--- a/constants/wallet.py
+++ b/constants/wallet.py
@@ -13,7 +13,9 @@ class WalletNetworkSettings(Enum):
     TESTNET_SUBTITLE = 'Switch entire Status app to testnet only mode'
     TESTNET_ENABLED_TOAST_MESSAGE = 'Testnet mode turned on'
     TESTNET_DISABLED_TOAST_MESSAGE = 'Testnet mode turned off'
-    ACKNOWLEDGMENT_CHECKBOX_TEXT = 'I understand that changing network settings can cause unforeseen issues, errors, security risks and potentially even loss of funds.'
+    ACKNOWLEDGMENT_CHECKBOX_TEXT = ('I understand that changing network settings can cause unforeseen issues, errors, '
+                                    'security risks and potentially even loss of funds.')
+    REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE = 'Live network settings for Mainnet reverted to default'
 
 
 class WalletNetworkNaming(Enum):

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -506,7 +506,7 @@ class EditNetworkSettings(WalletSettingsView):
         error = str(self._network_edit_failover_rpc_url_error_message.object.errorMessageCmp.text)
         return error
 
-    @allure.step('Click Revert to default button')
+    @allure.step('Click Revert button and make sure values are reset')
     def revert_to_default(self, attempts=2):
         current_value_main = self._network_main_json_rpc_url.text
         current_value_failover = self._network_failover_json_rpc_url.text
@@ -517,6 +517,12 @@ class EditNetworkSettings(WalletSettingsView):
             assert attempts > 0, "value not reverted"
             time.sleep(1)
             self.revert_to_default(attempts - 1)
+
+    @allure.step('Click Revert to default button and redirect to Networks screen')
+    def click_revert_to_default_and_go_to_networks_main_screen(self):
+        self._network_edit_scroll.vertical_down_to(self._network_revert_to_default)
+        self._network_revert_to_default.click()
+        return NetworkWalletSettings().wait_until_appears()
 
     @allure.step('Get value from Main json rpc input')
     def get_edit_network_main_json_rpc_url_value(self):

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
@@ -5,13 +5,13 @@ from allure_commons._allure import step
 import driver
 from constants.wallet import WalletNetworkNaming, WalletEditNetworkErrorMessages, WalletNetworkSettings, \
     WalletNetworkDefaultValues
+from gui.components.wallet.wallet_toast_message import WalletToastMessage
 from gui.main_window import MainWindow
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703515',
                  'Network:  Network: Editing network -> Restore defaults')
 @pytest.mark.case(703515)
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12416")
 def test_settings_networks_edit_restore_defaults(main_screen: MainWindow):
     networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
 
@@ -51,22 +51,21 @@ def test_settings_networks_edit_restore_defaults(main_screen: MainWindow):
         assert edit_network_form.get_acknowledgement_checkbox_text(
             'text') == WalletNetworkSettings.ACKNOWLEDGMENT_CHECKBOX_TEXT.value
 
-    with step('Click Revert to default button and restore values'):
-        edit_network_form.revert_to_default()
+    with step('Click Revert to default button and go to Networks screen'):
+        edit_network_form.click_revert_to_default_and_go_to_networks_main_screen()
+
+    with step('Verify toast message appears for reverting to defaults'):
+        assert WalletToastMessage().get_toast_message(WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value)
+
+    with step('Open Ethereum Mainnet network item to edit'):
+        edit_network_form = networks.click_network_item_to_open_edit_view(
+            WalletNetworkNaming.ETHEREUM_MAINNET_NETWORK_ID.value)
 
     with step('Check value in Main JSON RPC URL input'):
         assert edit_network_form.get_edit_network_main_json_rpc_url_value() == WalletNetworkDefaultValues.ETHEREUM_LIVE_MAIN.value
 
-    with step('Check successful connection message for Main JSON RPC URL input'):
-        assert driver.waitFor(
-            lambda: edit_network_form.get_main_rpc_url_error_message_text() == WalletEditNetworkErrorMessages.PINGVERIFIED.value)
-
     with (step('Check value in Failover JSON RPC URL input')):
         assert edit_network_form.get_edit_network_failover_json_rpc_url_value() == WalletNetworkDefaultValues.ETHEREUM_LIVE_FAILOVER.value
-
-    with step('Check successful connection message for Failover JSON RPC URL input'):
-        assert driver.waitFor(
-            lambda: edit_network_form.get_failover_rpc_url_error_message_text() == WalletEditNetworkErrorMessages.PINGVERIFIED.value)
 
     with step('Verify the acknowledgment checkbox is unchecked'):
         assert edit_network_form.check_acknowledgement_checkbox(False)

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
@@ -82,7 +82,6 @@ def test_toggle_testnet_toggle_on_and_close_the_confirmation(main_screen: MainWi
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703622',
                  'Network:  Network: Enable Testnets, toggle testnet toggle OFF, click cancel in confirmation')
 @pytest.mark.case(703621)
-# @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12247"), bug is now fixed
 def test_switch_testnet_off_by_toggle_and_cancel_in_confirmation(main_screen: MainWindow):
     networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
 


### PR DESCRIPTION
Fix the test to adjust to new navigation and add verification for toast message

https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/420/

<img width="1840" alt="Screenshot 2023-10-12 at 16 11 53" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/d97fe45f-84e2-44c2-9824-c640fc3bd62e">
