### PR TITLE
chore(@edit_network_test): get rid of 1x1 comparison

### DIFF
--- a/constants/wallet.py
+++ b/constants/wallet.py
@@ -33,10 +33,10 @@ class WalletNetworkNaming(Enum):
 
 
 class WalletNetworkDefaultValues(Enum):
-    ETHEREUM_LIVE_MAIN = 'https://eth-archival.gateway.pokt.network/v1/lb/************************'
-    ETHEREUM_TEST_MAIN = 'https://goerli-archival.gateway.pokt.network/v1/lb/************************'
-    ETHEREUM_LIVE_FAILOVER = 'https://mainnet.infura.io/v3/********************************'
-    ETHEREUM_TEST_FAILOVER = 'https://goerli.infura.io/v3/********************************'
+    ETHEREUM_LIVE_MAIN = 'https://eth-archival.gateway.pokt.network'
+    ETHEREUM_TEST_MAIN = 'https://goerli-archival.gateway.pokt.network'
+    ETHEREUM_LIVE_FAILOVER = 'https://mainnet.infura.io'
+    ETHEREUM_TEST_FAILOVER = 'https://goerli.infura.io'
 
 
 class WalletEditNetworkErrorMessages(Enum):

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -611,20 +611,32 @@ class EditNetworkSettings(WalletSettingsView):
         match network_tab:
             case WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
                 self._live_network_tab.click()
-                assert self.get_edit_network_main_json_rpc_url_value() == WalletNetworkDefaultValues.ETHEREUM_LIVE_MAIN.value
+                current_value = self.get_edit_network_main_json_rpc_url_value()
+                return True if current_value.startswith(
+                        WalletNetworkDefaultValues.ETHEREUM_LIVE_MAIN.value) and current_value.endswith("****") \
+                    else False
             case WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
                 self._test_network_tab.click()
-                assert self.get_edit_network_main_json_rpc_url_value() == WalletNetworkDefaultValues.ETHEREUM_TEST_MAIN.value
+                current_value = self.get_edit_network_main_json_rpc_url_value()
+                return True if current_value.startswith(
+                        WalletNetworkDefaultValues.ETHEREUM_TEST_MAIN.value) and current_value.endswith("****") \
+                    else False
 
     @allure.step('Verify value in Failover JSON RPC input')
     def verify_edit_network_failover_json_rpc_url_value(self, network_tab):
         match network_tab:
             case WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
                 self._live_network_tab.click()
-                assert self.get_edit_network_failover_json_rpc_url_value() == WalletNetworkDefaultValues.ETHEREUM_LIVE_FAILOVER.value
+                current_value = self.get_edit_network_failover_json_rpc_url_value()
+                return True if current_value.startswith(
+                        WalletNetworkDefaultValues.ETHEREUM_LIVE_FAILOVER.value) and current_value.endswith("****") \
+                    else False
             case WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
                 self._test_network_tab.click()
-                assert self.get_edit_network_failover_json_rpc_url_value() == WalletNetworkDefaultValues.ETHEREUM_TEST_FAILOVER.value
+                current_value = self.get_edit_network_failover_json_rpc_url_value()
+                return True if current_value.startswith(
+                        WalletNetworkDefaultValues.ETHEREUM_TEST_FAILOVER.value) and current_value.endswith("****") \
+                    else False
 
 
 class EditAccountOrderSettings(WalletSettingsView):

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
@@ -67,10 +67,12 @@ def test_settings_networks_edit_restore_defaults(main_screen: MainWindow, networ
             WalletNetworkNaming.ETHEREUM_MAINNET_NETWORK_ID.value)
 
     with step('Verify value in Main JSON RPC URL input'):
-        edit_network_form.verify_edit_network_main_json_rpc_url_value(network_tab)
+        assert edit_network_form.verify_edit_network_main_json_rpc_url_value(network_tab), \
+            f"Reverted value in Main JSON RPC is incorrect"
 
     with (step('Verify value in Failover JSON RPC URL input')):
-        edit_network_form.verify_edit_network_failover_json_rpc_url_value(network_tab)
+        assert edit_network_form.verify_edit_network_failover_json_rpc_url_value(network_tab), \
+            f"Reverted value in Failover JSON RPC is incorrect"
 
     with step('Verify the acknowledgment checkbox is unchecked'):
         assert edit_network_form.check_acknowledgement_checkbox(False, network_tab)


### PR DESCRIPTION
I wanted to get rid of equal comparison of value in the RPC url field, because i noticed , that the number of `**` symbols differ from build to build (it happens because we use different keys for release , nightly, pr builds). So, to exclude the possible failure when test will compare the exact strings, i replaced the verification with a check that verifies:

- the url starts with the provider url pattern
- the url ends with at least 4 star symbols (normally the api key is longer than 4 symbols).

Having that matching with AND condition allows us to verify:
- the value is reset indeed
- the value is very similar to the one we expect
- the URL will not depend on exact number of stars in the end


https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/450/

<img width="1840" alt="Screenshot 2023-10-13 at 17 19 09" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/0f7aad25-5532-46c0-892f-85fecfe5fd83">
