### PR TITLE
chore(@wallet_settings_tests): enable back account ordering

### DIFF
--- a/tests/settings/settings_wallet/test_wallet_settings_account_order.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_account_order.py
@@ -16,7 +16,6 @@ from scripts.tools import image
     pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'Status account',
                  'WatchOnly', '#2a4af5', 'sunglasses', 'Generated', '#216266', 'thumbsup')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/165")
 def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_account, address: str, default_name,
                                                name: str, color: str, emoji: str, second_name: str, second_color: str,
                                                second_emoji: str):
@@ -54,7 +53,7 @@ def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_acc
             assert driver.waitFor(lambda: account_order.accounts[1].name == second_name)
             assert driver.waitFor(lambda: account_order.accounts[2].name == default_name)
         with step('Account order is correct in wallet'):
-            wallet = main_screen.left_panel.open_wallet()
+            wallet = main_screen.left_panel.open_wallet().wait_until_appears()
             assert driver.waitFor(lambda: wallet.left_panel.accounts[0].name == name)
             assert driver.waitFor(lambda: wallet.left_panel.accounts[1].name == second_name)
             assert driver.waitFor(lambda: wallet.left_panel.accounts[2].name == default_name)


### PR DESCRIPTION
Account ordering test is fixed and passing now

https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/518/

<img width="1840" alt="Screenshot 2023-10-19 at 18 18 09" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/15c653f8-e659-45d3-aa7f-d2306c885f07">
