### PR TITLE
Fix AttachError because of parallel execution

### DIFF
--- a/configs/squish.py
+++ b/configs/squish.py
@@ -1,2 +1,4 @@
-AUT_PORT = 61500
-SERVET_PORT = 4322
+import os
+
+AUT_PORT = 61500 + int(os.getenv('BUILD_NUMBER', 0))
+SERVER_PORT = 4322 + int(os.getenv('BUILD_NUMBER', 0))

--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ from PIL import ImageGrab
 
 import configs
 import driver
+from configs.system import IS_LIN
 from fixtures.path import generate_test_info
 from scripts.utils import local_system
 from scripts.utils.system_path import SystemPath
@@ -57,7 +58,7 @@ def pytest_exception_interact(node):
         screenshot = node_dir / 'screenshot.png'
         if screenshot.exists():
             screenshot = node_dir / f'screenshot_{datetime.now():%H%M%S}.png'
-        ImageGrab.grab().save(screenshot)
+        ImageGrab.grab(xdisplay=":0" if IS_LIN else None).save(screenshot)
         allure.attach(
             name='Screenshot on fail',
             body=screenshot.read_bytes(),

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -7,6 +7,7 @@ from PIL import ImageGrab
 
 import configs
 import driver
+from configs.system import IS_LIN
 from driver import context
 from driver.server import SquishServer
 from scripts.utils import system_path, local_system
@@ -43,7 +44,7 @@ class AUT:
             screenshot = configs.testpath.RUN / 'screenshot.png'
             if screenshot.exists():
                 screenshot = configs.testpath.RUN / f'screenshot_{datetime.now():%H%M%S}.png'
-            ImageGrab.grab().save(screenshot)
+            ImageGrab.grab(xdisplay=":0" if IS_LIN else None).save(screenshot)
             allure.attach(
                 name='Screenshot on fail',  body=screenshot.read_bytes(), attachment_type=allure.attachment_type.PNG)
         self.detach().stop()

--- a/driver/context.py
+++ b/driver/context.py
@@ -5,6 +5,7 @@ import allure
 import squish
 
 import configs
+from driver.server import SquishServer
 
 _logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ def attach(aut_id: str, timeout_sec: int = configs.timeouts.PROCESS_TIMEOUT_SEC)
     _logger.debug(f'Attaching to {aut_id}')
     while True:
         try:
-            context = squish.attachToApplication(aut_id)
+            context = squish.attachToApplication(aut_id, SquishServer().host, SquishServer().port)
             _logger.info(f'AUT: {aut_id} attached')
             return context
         except RuntimeError as err:


### PR DESCRIPTION
I found that we Attaching AUT to the default Server port, but the server port changed for each run.
In PR I marked the Squish server as a singleton to have the constant parameters of the Squish server during the test execution.
I added shifting of the squish server port, depending on the build number, to avoid the case when the squish server started on the same port for all parallel jobs.

Test Run, parallel execution:

- https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/556/allure
- https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/555/allure