### PR TITLE
chore(@onboarding_syncing): uncomment sync devices test

### DIFF
--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -12,7 +12,6 @@ from gui.components.splash_screen import SplashScreen
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, BiometricsView, KeysView
 
 _logger = logging.getLogger(__name__)
-pytestmark = allure.suite("Onboarding")
 
 
 @pytest.fixture

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -15,7 +15,6 @@ from gui.main_window import MainWindow
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, SyncResultView, \
     SyncCodeView, SyncDeviceFoundView
 
-pytestmark = allure.suite("Syncing")
 
 
 @pytest.fixture
@@ -31,7 +30,6 @@ def sync_screen(main_window) -> SyncCodeView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703592', 'Sync device during onboarding')
 @pytest.mark.case(703592)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'user_account_one'])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/174")
 def test_sync_device_during_onboarding(multiple_instance, user_data):
     user: UserAccount = constants.user_account_one
     main_window = MainWindow()


### PR DESCRIPTION
`test_sync_device_during_onboarding` is enabled now

https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/567/

<img width="1840" alt="Screenshot 2023-10-22 at 19 34 05" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/e08c4fe5-fde1-446b-8662-69282f4ccde7">


