### PR TITLE
chore(@onboarding_test): add verification for wallet address

### DIFF
--- a/constants/user.py
+++ b/constants/user.py
@@ -1,27 +1,31 @@
+import random
+import string
 from collections import namedtuple
 
 import configs
 
-UserAccount = namedtuple('User', ['name', 'password', 'seed_phrase'])
+UserAccount = namedtuple('User', ['name', 'password', 'seed_phrase', 'status_address'])
 user_account_one = UserAccount('squisher', '0000000000', [
     'rail', 'witness', 'era', 'asthma', 'empty', 'cheap', 'shed', 'pond', 'skate', 'amount', 'invite', 'year'
-])
+], '0x3286c371ef648fe6232324b27ee0515f4ded24d9')
 user_account_two = UserAccount('athletic', '0000000000', [
     'measure', 'cube', 'cousin', 'debris', 'slam', 'ignore', 'seven', 'hat', 'satisfy', 'frown', 'casino', 'inflict'
-])
-user_account_three = UserAccount('nervous', '0000000000', [])
+], '0x99C096bB5F12bDe37DE9dbee8257Ebe2a5667C46')
+user_account_three = UserAccount('nervous', '0000000000', [], '')
 
-user_account_one_changed_password = UserAccount('squisher', 'NewPassword@12345', [])
+user_account_one_changed_password = UserAccount('squisher', 'NewPassword@12345', [], '')
 
-user_account_one_changed_name = UserAccount('NewUserName', '0000000000', [])
+user_account_one_changed_name = UserAccount('NewUserName', '0000000000', [], '')
 
 community_params = {
     'name': 'Name',
     'description': 'Description',
     'logo': {'fp': configs.testpath.TEST_FILES / 'tv_signal.png', 'zoom': None, 'shift': None},
     'banner': {'fp': configs.testpath.TEST_FILES / 'banner.png', 'zoom': None, 'shift': None},
-    'intro': 'Intro',
-    'outro': 'Outro'
+    'intro': ''.join(random.choices(string.ascii_letters +
+                                    string.digits, k=200)),
+    'outro': ''.join(random.choices(string.ascii_letters +
+                                    string.digits, k=80))
 }
 
 UserCommunityInfo = namedtuple('CommunityInfo', ['name', 'description', 'members', 'image'])

--- a/gui/objects_map/settings_names.py
+++ b/gui/objects_map/settings_names.py
@@ -72,6 +72,14 @@ walletAccountViewEditAccountButton = {"container": statusDesktop_mainWindow, "ob
 walletAccountViewAccountName = {"container": statusDesktop_mainWindow, "objectName": "walletAccountViewAccountName", "type": "StatusBaseText"}
 walletAccountViewAccountEmoji = {"container": statusDesktop_mainWindow, "objectName": "walletAccountViewAccountImage", "type": "StatusEmoji", "visible": True}
 walletAccountViewDeleteAccountButton = {"container": statusDesktop_mainWindow, "objectName": "deleteAccountButton", "type": "StatusButton"}
+walletAccountViewDetailsLabel = {"container": settingsContentBase_ScrollView, "objectName": "AccountDetails_TextLabel", "type": "StatusBaseText"}
+walletAccountViewBalance = {"container": settingsContentBase_ScrollView, "objectName": "Balance_ListItem", "type": "WalletAccountDetailsListItem"}
+walletAccountViewAddress = {"container": settingsContentBase_ScrollView, "objectName": "Address_ListItem", "type": "WalletAccountDetailsListItem"}
+walletAccountViewKeypairItem = {"container": settingsContentBase_ScrollView, "objectName": "KeyPair_Item", "type": "WalletAccountDetailsKeypairItem"}
+walletAccountViewOrigin = {"container": settingsContentBase_ScrollView, "objectName": "Origin_ListItem", "type": "WalletAccountDetailsListItem"}
+walletAccountViewDerivationPath = {"container": settingsContentBase_ScrollView, "objectName": "DerivationPath_ListItem", "type": "WalletAccountDetailsListItem"}
+walletAccountViewStored = {"container": settingsContentBase_ScrollView, "objectName": "Stored_ListItem", "type": "WalletAccountDetailsListItem"}
+walletAccountViewPreferredNetworks = {"container": settingsContentBase_ScrollView, "objectName": "PreferredNetworks_ListItem", "type": "StatusListItem"}
 
 # Wallet edit network view
 settingsContentBaseScrollView_editPreviwTabBar_StatusTabBar = {"container": statusDesktop_mainWindow, "objectName": "editPreviwTabBar", "type": "StatusTabBar"}

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -60,6 +60,14 @@ class AccountDetailsView(WalletSettingsView):
         self._delete_account_button = Button('walletAccountViewDeleteAccountButton')
         self._wallet_account_title = TextLabel('walletAccountViewAccountName')
         self._wallet_account_emoji = QObject('walletAccountViewAccountEmoji')
+        self._wallet_account_details_label = TextLabel('walletAccountViewDetailsLabel')
+        self._wallet_account_balance = QObject('walletAccountViewBalance')
+        self._wallet_account_keypair_item = QObject('walletAccountViewKeypairItem')
+        self._wallet_account_address = QObject('walletAccountViewAddress')
+        self._wallet_account_origin = TextLabel('walletAccountViewOrigin')
+        self._wallet_account_derivation_path = QObject('walletAccountViewDerivationPath')
+        self._wallet_account_stored = TextLabel('walletAccountViewStored')
+        self._wallet_preferred_networks = QObject('walletAccountViewPreferredNetworks')
 
     @allure.step('Click Edit button')
     def click_edit_account_button(self):
@@ -73,6 +81,12 @@ class AccountDetailsView(WalletSettingsView):
     @allure.step('Get account name')
     def get_account_name_value(self):
         return self._wallet_account_title.text
+
+    @allure.step("Get account address value")
+    def get_account_address_value(self):
+        raw_value = str(self._wallet_account_address.get_object_attribute('subTitle'))
+        address = raw_value.split(">")[-1]
+        return address
 
     @allure.step('Get account color value')
     def get_account_color_value(self):

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -13,7 +13,6 @@ from gui.main_window import MainWindow
 from gui.screens.community import CommunityScreen
 from scripts.tools import image
 
-pytestmark = allure.suite("Communities")
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703084', 'Create community')

--- a/tests/communities/test_permissions.py
+++ b/tests/communities/test_permissions.py
@@ -8,7 +8,6 @@ from constants.permissions import PermissionsElements
 from gui.main_window import MainWindow
 from scripts.tools import image
 
-pytestmark = allure.suite("Communities")
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703198',

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -9,7 +9,6 @@ from constants.group_chat import GroupChatMessages
 from gui.main_window import MainWindow
 from gui.screens.messages import MessagesScreen
 
-pytestmark = allure.suite("Messaging")
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703014', 'Create a group and send messages')

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -46,6 +46,13 @@ def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, au
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 
+    with (step('Verify that restored account reveals correct status wallet address')):
+        status_acc_view = (
+            main_window.left_panel.open_settings().left_panel.open_wallet_settings().open_status_account_in_settings())
+        address = status_acc_view.get_account_address_value()
+        assert address == user_account.status_address, \
+            f"Recovered account should have address {user_account.status_address}, but has {address}"
+
     with step('Verify that the user logged in via seed phrase correctly'):
         user_canvas = main_window.left_panel.open_user_canvas()
         profile_popup = user_canvas.open_profile_popup()

--- a/tests/wallet/test_wallet_main_manage_accounts.py
+++ b/tests/wallet/test_wallet_main_manage_accounts.py
@@ -185,7 +185,7 @@ def test_private_key_imported_account(main_screen: MainWindow, user_account,
                                       name: str, color: str, emoji: str, emoji_unicode: str,
                                       new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str,
                                       private_key: str):
-    with step('Create generated wallet account'):
+    with step('Import an account within private key'):
         wallet = main_screen.left_panel.open_wallet()
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()


### PR DESCRIPTION
It is important to verify  that when u recover an account, the wallet address of your status account is the one that belongs to your seed phrase

Fixes https://github.com/status-im/desktop-qa-automation/issues/200

https://ci.status.im/job/status-desktop/job/e2e/job/linux-tests/584/