### PR TITLE
chore(@wallet_account_tests): make sure status account can't be deleted, as well as correct wallet address is restored for importing account

### DIFF
--- a/constants/user.py
+++ b/constants/user.py
@@ -33,3 +33,6 @@ UserChannel = namedtuple('Channel', ['name', 'image', 'selected'])
 
 account_list_item = namedtuple('AccountListItem', ['name', 'color', 'emoji'])
 wallet_account_list_item = namedtuple('WalletAccountListItem', ['name', 'icon', 'object'])
+
+wallet_account = namedtuple('PrivateKeyAddressPair', ['private_key', 'wallet_address'])
+private_key_address_pair_1 = wallet_account('2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470', '0xd89b48cbcb4244f84a4fb5d3369c120e8f8aa74e')

--- a/gui/components/context_menu.py
+++ b/gui/components/context_menu.py
@@ -28,3 +28,7 @@ class ContextMenu(QObject):
     @allure.step('Select edit account option from context menu')
     def select_edit_account_from_context_menu(self):
         self._context_edit_account_option.click()
+
+    @allure.step('Check delete option visibility in context menu')
+    def is_delete_account_option_present(self):
+        return self._context_delete_account_option.is_visible

--- a/gui/objects_map/settings_names.py
+++ b/gui/objects_map/settings_names.py
@@ -1,4 +1,5 @@
 from gui.objects_map.main_names import statusDesktop_mainWindow
+from objectmaphelper import *
 
 mainWindow_ProfileLayout = {"container": statusDesktop_mainWindow, "type": "ProfileLayout", "unnamed": 1, "visible": True}
 mainWindow_StatusSectionLayout_ContentItem = {"container": mainWindow_ProfileLayout, "objectName": "StatusSectionLayout", "type": "ContentItem", "visible": True}
@@ -66,6 +67,7 @@ networkSettingsNetworks_Arbitrum_Goerli = {"container": settingsContentBase_Scro
 networkSettingsNetworks_Mainnet_Goerli_sensor = {"container": networkSettingsNetworks_Mainnet_Goerli, "objectName": "walletNetworkDelegate_Mainnet_5_sensor", "id": "sensor", "type": "MouseArea", "unnamed": 1, "visible": True}
 networkSettingsNetowrks_Mainnet_Testlabel = {"container": networkSettingsNetworks_Mainnet_Goerli_sensor, "objectName": "testnetLabel_Mainnet", "type": "StatusBaseText", "visible": True}
 settingsWalletAccountDelegate_Status_account = {"container": settingsContentBase_ScrollView, "objectName": "Status account", "type": "WalletAccountDelegate", "visible": True}
+settingsWalletAccountDelegate = {"container": settingsContentBase_ScrollView, "objectName": RegularExpression("*"), "type": "WalletAccountDelegate", "visible": True}
 
 # Wallet Account Details view
 walletAccountViewEditAccountButton = {"container": statusDesktop_mainWindow, "objectName": "walletAccountViewEditAccountButton", "type": "StatusButton"}

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -30,6 +30,7 @@ class WalletSettingsView(QObject):
         self._wallet_network_button = Button('settings_Wallet_MainView_Networks')
         self._account_order_button = Button('settingsContentBaseScrollView_accountOrderItem_StatusListItem')
         self._status_account_in_keypair = QObject('settingsWalletAccountDelegate_Status_account')
+        self._wallet_account_from_keypair = QObject('settingsWalletAccountDelegate')
 
     @allure.step('Open add account pop up in wallet settings')
     def open_add_account_pop_up(self):
@@ -49,6 +50,12 @@ class WalletSettingsView(QObject):
     @allure.step('Open Status account view in wallet settings')
     def open_status_account_in_settings(self):
         self._status_account_in_keypair.click()
+        return AccountDetailsView().wait_until_appears()
+
+    @allure.step('Open account view in wallet settings by name')
+    def open_account_in_settings(self, name):
+        self._wallet_account_from_keypair.real_name['objectName'] = name
+        self._wallet_account_from_keypair.click()
         return AccountDetailsView().wait_until_appears()
 
 

--- a/tests/wallet/test_wallet_main_manage_accounts.py
+++ b/tests/wallet/test_wallet_main_manage_accounts.py
@@ -11,8 +11,6 @@ from gui.components.wallet.authenticate_popup import AuthenticatePopup
 from gui.main_window import MainWindow
 from gui.screens.settings_keycard import KeycardSettingsView
 
-pytestmark = allure.suite("Wallet")
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703022', 'Edit default wallet account')
 @pytest.mark.case(703022)
@@ -25,6 +23,11 @@ def test_edit_default_wallet_account(main_screen: MainWindow, name: str, new_nam
         wallet = main_screen.left_panel.open_wallet()
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         wallet.left_panel.select_account(name)
+
+    with step("Verify default status account can't be deleted"):
+        context_menu = wallet.left_panel._open_context_menu_for_account(name)
+        assert not context_menu.is_delete_account_option_present(), \
+            f"Delete option should not be present for Status account"
 
     with step('Edit wallet account'):
         account_popup = wallet.left_panel.open_edit_account_popup_from_context_menu(name)
@@ -175,21 +178,20 @@ def test_manage_custom_generated_account(main_screen: MainWindow, user_account,
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703029', 'Manage a private key imported account')
 @pytest.mark.case(703029)
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('address_pair', [constants.user.private_key_address_pair_1])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
-                         'new_name, new_color, new_emoji, new_emoji_unicode, private_key', [
+                         'new_name, new_color, new_emoji, new_emoji_unicode', [
                              pytest.param('PrivKeyAcc1', '#2a4af5', 'sunglasses', '1f60e',
-                                          'PrivKeyAcc1edited', '#216266', 'thumbsup', '1f44d',
-                                          '2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470')
+                                          'PrivKeyAcc1edited', '#216266', 'thumbsup', '1f44d')
                          ])
-def test_private_key_imported_account(main_screen: MainWindow, user_account,
+def test_private_key_imported_account(main_screen: MainWindow, user_account, address_pair,
                                       name: str, color: str, emoji: str, emoji_unicode: str,
-                                      new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str,
-                                      private_key: str):
+                                      new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str):
     with step('Import an account within private key'):
         wallet = main_screen.left_panel.open_wallet()
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
-        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_private_key(private_key).save()
+        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_private_key(address_pair.private_key).save()
         AuthenticatePopup().wait_until_appears().authenticate(user_account.password)
         account_popup.wait_until_hidden()
 
@@ -201,7 +203,15 @@ def test_private_key_imported_account(main_screen: MainWindow, user_account,
             if time.monotonic() - started_at > 15:
                 raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
 
+    with step('Verify that importing private key reveals correct wallet address'):
+        settings_acc_view = (
+            main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_account_in_settings(name))
+        address = settings_acc_view.get_account_address_value()
+        assert address == address_pair.wallet_address, \
+            f"Recovered account should have address {address_pair.wallet_address}, but has {address}"
+
     with step('Edit wallet account'):
+        main_screen.left_panel.open_wallet()
         account_popup = wallet.left_panel.open_edit_account_popup_from_context_menu(name)
         account_popup.set_name(new_name).set_emoji(new_emoji).set_color(new_color).save()
 


### PR DESCRIPTION
- Add verification for status default account is not having delete option in context menu (similar verification is also present in managing accounts from settings). We used to have a bug when delete button was present for status account
- Add verification for importing private account test, so the imported key gets us correct (expected) wallet address

https://ci.status.im/job/status-desktop/job/e2e/job/manual/605/

<img width="1840" alt="Screenshot 2023-10-24 at 10 47 41" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/aa6b2427-0541-42c5-b98e-91da802061b2">

<img width="1840" alt="Screenshot 2023-10-24 at 10 48 18" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/06dd5430-5b16-49bf-96e2-53350bf201d4">
