### PR TITLE
chore: settings tests are updated to handle reworked method to get toasts

### DIFF
--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -217,11 +217,17 @@ class EditNetworkSettings(WalletSettingsView):
     def check_toast_message(self, network_tab):
         match network_tab:
             case WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
-                assert (WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value in
-                        WalletToastMessage().get_toast_messages)
+                assert len(WalletToastMessage().get_toast_messages) == 1, \
+                    f"Multiple toast messages appeared"
+                message = WalletToastMessage().get_toast_messages[0]
+                assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value, \
+                    f"Toast message is incorrect, current message is {message}"
             case WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
-                assert (WalletNetworkSettings.REVERT_TO_DEFAULT_TEST_MAINNET_TOAST_MESSAGE.value in
-                        WalletToastMessage().get_toast_messages)
+                assert len(WalletToastMessage().get_toast_messages) == 1, \
+                    f"Multiple toast messages appeared"
+                message = WalletToastMessage().get_toast_messages[0]
+                assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_TEST_MAINNET_TOAST_MESSAGE.value, \
+                    f"Toast message is incorrect, current message is {message}"
 
     @allure.step('Verify elements for the edit network view')
     def check_available_elements_on_edit_view(self, network_tab):

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
@@ -28,8 +28,11 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().click_turn_on_testnet_mode_in_testnet_modal()
 
     with step('Verify that Testnet mode turned on'):
-        assert WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value in WalletToastMessage().get_toast_messages
-        assert len(WalletToastMessage().get_toast_messages) == 1
+        assert len(WalletToastMessage().get_toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = WalletToastMessage().get_toast_messages[0]
+        assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
+            f"Toast message is incorrect, current message is {message}"
         TestnetModeBanner().wait_until_appears()
         assert networks.is_testnet_mode_toggle_checked(), f"Testnet toggle if off when it should not"
 
@@ -46,7 +49,10 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().turn_off_testnet_mode_in_testnet_modal()
 
     with step('Verify that Testnet mode turned off'):
-        WalletToastMessage().get_toast_message(WalletNetworkSettings.TESTNET_DISABLED_TOAST_MESSAGE.value)
+        assert len(WalletToastMessage().get_toast_messages) == 2
+        message = WalletToastMessage().get_toast_messages[1]
+        assert message == WalletNetworkSettings.TESTNET_DISABLED_TOAST_MESSAGE.value, \
+            f"Toast message is incorrect, current message is {message}"
         TestnetModeBanner().wait_until_hidden()
         assert not networks.is_testnet_mode_toggle_checked(), f"Testnet toggle is on when it should not"
 
@@ -94,7 +100,11 @@ def test_switch_testnet_off_by_toggle_and_cancel_in_confirmation(main_screen: Ma
         testnet_modal.click_turn_on_testnet_mode_in_testnet_modal()
 
     with step('Verify testnet mode is enabled'):
-        WalletToastMessage().get_toast_message(WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value)
+        assert len(WalletToastMessage().get_toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = WalletToastMessage().get_toast_messages[0]
+        assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
+            f"Toast message is incorrect, current message is {message}"
         TestnetModeBanner().wait_until_appears()
         assert networks.is_testnet_mode_toggle_checked(), f"testnet toggle is off"
 


### PR DESCRIPTION
Fix settings tests to handle reworked method of getting toast messages

https://ci.status.im/job/status-desktop/job/e2e/job/manual/643/

<img width="1840" alt="Screenshot 2023-10-25 at 18 34 03" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/9199a9c2-c7b7-4bd4-af46-f351313d0836">
