### PR TITLE
chore: add attempts for clicking network and next buttons

### DIFF
--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -288,10 +288,16 @@ class YourProfileView(OnboardingView):
         return PictureEditPopup().wait_until_appears()
 
     @allure.step('Open Emoji and Icon view')
-    def next(self) -> 'EmojiAndIconView':
+    def next(self, attempts: int = 2) -> 'EmojiAndIconView':
         self._next_button.click()
-        time.sleep(1)
-        return EmojiAndIconView()
+        try:
+            return EmojiAndIconView().wait_until_appears()
+        except AssertionError as err:
+            if attempts:
+                return self.next(attempts - 1)
+            else:
+                raise err
+
 
     @allure.step('Go back')
     def back(self):

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -38,9 +38,15 @@ class WalletSettingsView(QObject):
         return AccountPopup().wait_until_appears()
 
     @allure.step('Open networks in wallet settings')
-    def open_networks(self):
+    def open_networks(self, attempts: int = 2):
         self._wallet_network_button.click()
-        return NetworkWalletSettings().wait_until_appears()
+        try:
+            return NetworkWalletSettings().wait_until_appears()
+        except AssertionError as err:
+            if attempts:
+                return self.open_networks(attempts - 1)
+            else:
+                raise err
 
     @allure.step('Open account order in wallet settings')
     def open_account_order(self):

--- a/tests/communities/test_airdrops.py
+++ b/tests/communities/test_airdrops.py
@@ -12,6 +12,7 @@ from scripts.tools import image
                  'Manage community: Manage Airdrops screen overview')
 @pytest.mark.case(703200)
 @pytest.mark.parametrize('params', [constants.community_params])
+@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/186')
 def test_airdrops_screen(main_screen: MainWindow, params):
     with step('Create community'):
         main_screen.create_community(params)

--- a/tests/communities/test_tokens.py
+++ b/tests/communities/test_tokens.py
@@ -12,6 +12,7 @@ from scripts.tools import image
                  'Manage community: Manage Mint Tokens screen overview')
 @pytest.mark.case(703199)
 @pytest.mark.parametrize('params', [constants.community_params])
+@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/186')
 def test_tokens_screen(main_screen: MainWindow, params):
     with step('Create community'):
         main_screen.create_community(params)

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -20,8 +20,8 @@ def keys_screen(main_window) -> KeysView:
         if configs.system.IS_MAC:
             AllowNotificationsView().wait_until_appears().allow()
         BeforeStartedPopUp().get_started()
-        wellcome_screen = WelcomeToStatusView().wait_until_appears()
-        return wellcome_screen.get_keys()
+        welcome_screen = WelcomeToStatusView().wait_until_appears()
+        return welcome_screen.get_keys()
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703421', 'Generate new keys')


### PR DESCRIPTION
- hopefully fixes https://github.com/status-im/desktop-qa-automation/issues/215
- also, add attempt param to method which clicks the Next button for onboarding
- comment the new tests for communities, because community creation is still not working properly

https://ci.status.im/job/status-desktop/job/e2e/job/manual/659/

<img width="1840" alt="Screenshot 2023-10-26 at 11 06 35" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/72951baf-ff83-4bc3-be32-3b7eb02b9abc">
