### PR TITLE
chore: enable test_onboarding_syncing.py

### DIFF
--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -16,7 +16,6 @@ from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, 
     SyncCodeView, SyncDeviceFoundView
 
 
-
 @pytest.fixture
 def sync_screen(main_window) -> SyncCodeView:
     with step('Open Syncing view'):
@@ -30,7 +29,6 @@ def sync_screen(main_window) -> SyncCodeView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703592', 'Sync device during onboarding')
 @pytest.mark.case(703592)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'user_account_one'])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12550")
 def test_sync_device_during_onboarding(multiple_instance, user_data):
     user: UserAccount = constants.user_account_one
     main_window = MainWindow()


### PR DESCRIPTION
https://github.com/status-im/status-desktop/issues/12550 is fixed, enable the test back

https://ci.status.im/job/status-desktop/job/e2e/job/manual/695/

<img width="1840" alt="Screenshot 2023-10-30 at 11 09 40" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/47c1f90c-f2d0-473b-acd3-219cf34d6117">
