### PR TITLE
chore: add attempts to click on Next button for onboarding

### DIFF
--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -12,6 +12,7 @@ from constants import ColorCodes
 from driver.objects_access import walk_children
 from gui.components.os.open_file_dialogs import OpenFileDialog
 from gui.components.picture_edit_popup import PictureEditPopup
+from gui.components.splash_screen import SplashScreen
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.text_edit import TextEdit
@@ -183,8 +184,13 @@ class SyncResultView(OnboardingView):
         return self
 
     @allure.step('Sign in')
-    def sign_in(self):
+    def sign_in(self, attempts: int = 2):
         self._sign_in_button.click()
+        try:
+            return SplashScreen().wait_until_appears()
+        except:
+            assert attempts > 0, f'Next button was not clicked'
+            self.sign_in(attempts - 1)
 
 
 class SeedPhraseInputView(OnboardingView):
@@ -297,7 +303,6 @@ class YourProfileView(OnboardingView):
                 return self.next(attempts - 1)
             else:
                 raise err
-
 
     @allure.step('Go back')
     def back(self):

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -74,7 +74,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
 
         with step('Sign in to synced account'):
             sync_result.sign_in()
-            SplashScreen().wait_until_appears().wait_until_hidden()
+            SplashScreen().wait_until_hidden()
             if not configs.DEV_BUILD:
                 if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
                     BetaConsentPopup().confirm()


### PR DESCRIPTION
I reviewed the results for our tests in PRs today. I noticed this:

https://ci.status.im/job/status-desktop/job/e2e/job/prs/143/

<img width="2032" alt="Screenshot 2023-10-30 at 18 05 10" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/552aceb1-7b71-4cb0-bd46-a523d22d07e8">

I made an attempt to fix that by adding additional click for Next button

https://ci.status.im/job/status-desktop/job/e2e/job/manual/700/