### PR TITLE
Chore/display

### DIFF
--- a/configs/system.py
+++ b/configs/system.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 IS_LIN = True if platform.system() == 'Linux' else False
@@ -5,3 +6,5 @@ IS_MAC = True if platform.system() == 'Darwin' else False
 IS_WIN = True if platform.system() == 'Windows' else False
 
 OS_ID = 'lin' if IS_LIN else 'mac' if IS_MAC else 'win'
+
+DISPLAY = os.getenv('DISPLAY', ':0')

--- a/conftest.py
+++ b/conftest.py
@@ -58,7 +58,7 @@ def pytest_exception_interact(node):
         screenshot = node_dir / 'screenshot.png'
         if screenshot.exists():
             screenshot = node_dir / f'screenshot_{datetime.now():%H%M%S}.png'
-        ImageGrab.grab(xdisplay=":0" if IS_LIN else None).save(screenshot)
+        ImageGrab.grab(xdisplay=configs.system.DISPLAY if IS_LIN else None).save(screenshot)
         allure.attach(
             name='Screenshot on fail',
             body=screenshot.read_bytes(),

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -44,7 +44,7 @@ class AUT:
             screenshot = configs.testpath.RUN / 'screenshot.png'
             if screenshot.exists():
                 screenshot = configs.testpath.RUN / f'screenshot_{datetime.now():%H%M%S}.png'
-            ImageGrab.grab(xdisplay=":0" if IS_LIN else None).save(screenshot)
+            ImageGrab.grab(xdisplay=configs.system.DISPLAY if IS_LIN else None).save(screenshot)
             allure.attach(
                 name='Screenshot on fail',  body=screenshot.read_bytes(), attachment_type=allure.attachment_type.PNG)
         self.stop()

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -18,7 +18,6 @@ from scripts.tools import image
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703084', 'Create community')
 @pytest.mark.case(703084)
 @pytest.mark.parametrize('params', [constants.community_params])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
 def test_create_community(user_account, main_screen: MainWindow, params):
     with step('Create community'):
         communities_portal = main_screen.left_panel.open_communities_portal()


### PR DESCRIPTION
Test run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/709/
Testing screenshot on fail for parallel execution: 
- https://ci.status.im/job/status-desktop/job/e2e/job/manual/712/
- https://ci.status.im/job/status-desktop/job/e2e/job/manual/713/

I'm not sure that the issue was fixed, the idea was that I grabbed a screenshot from the wrong screen, and by default, it was ':0', now we are getting a screen number from CI. Will see. 

If it appears again I would skip Linux-3, because it appears only there

