### PR TITLE
test: test_wallet_main_can_add_account_after_restart implemented

### DIFF
--- a/constants/user.py
+++ b/constants/user.py
@@ -34,5 +34,8 @@ UserChannel = namedtuple('Channel', ['name', 'image', 'selected'])
 account_list_item = namedtuple('AccountListItem', ['name', 'color', 'emoji'])
 wallet_account_list_item = namedtuple('WalletAccountListItem', ['name', 'icon', 'object'])
 
+account_list_item_2 = namedtuple('AccountListItem', ['name2', 'color2', 'emoji2'])
+wallet_account_list_item_2 = namedtuple('WalletAccountListItem', ['name', 'icon', 'object'])
+
 wallet_account = namedtuple('PrivateKeyAddressPair', ['private_key', 'wallet_address'])
 private_key_address_pair_1 = wallet_account('2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470', '0xd89b48cbcb4244f84a4fb5d3369c120e8f8aa74e')

--- a/gui/components/signing_phrase_popup.py
+++ b/gui/components/signing_phrase_popup.py
@@ -2,15 +2,21 @@ import allure
 
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
+from gui.elements.object import QObject
 
 
-class SigningPhrasePopup(BasePopup):
+class SigningPhrasePopup(QObject):
 
     def __init__(self):
-        super(SigningPhrasePopup, self).__init__()
+        super(SigningPhrasePopup, self).__init__('signPhrase_Ok_Button')
         self._ok_got_it_button = Button('signPhrase_Ok_Button')
 
     @allure.step('Confirm signing phrase in popup')
     def confirm_phrase(self):
         self._ok_got_it_button.click()
         SigningPhrasePopup().wait_until_hidden()
+
+    @allure.step('Verify if the signing phrase popup is visible')
+    def is_ok_got_it_button_visible(self):
+        return self._ok_got_it_button.is_visible
+

--- a/tests/wallet_main_screen/test_wallet_main_can_add_account_after_restart.py
+++ b/tests/wallet_main_screen/test_wallet_main_can_add_account_after_restart.py
@@ -1,0 +1,81 @@
+import time
+
+import allure
+import pytest
+from allure import step
+
+import constants
+import driver
+from driver.aut import AUT
+from gui.components.signing_phrase_popup import SigningPhrasePopup
+from gui.components.wallet.authenticate_popup import AuthenticatePopup
+from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.main_window import MainWindow
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704459',
+                 'User can add  one more account after restarting the app')
+@pytest.mark.case(704459)
+@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('name, color, emoji, emoji_unicode,',
+                         [
+                             pytest.param('GenAcc1', '#2a4af5', 'sunglasses', '1f60e')
+                         ])
+@pytest.mark.parametrize('name2, color2, emoji2, emoji_unicode2,',
+                         [
+                             pytest.param('GenAcc2', '#2a4af5', 'sunglasses', '1f60e')
+                         ])
+def test_add_generated_account_restart_add_again(
+        aut: AUT, main_screen: MainWindow, user_account,
+        color: str, emoji: str, emoji_unicode: str, name: str,
+        color2: str, emoji2: str, emoji_unicode2: str, name2: str,
+):
+    with step('Add the first generated wallet account'):
+        wallet = main_screen.left_panel.open_wallet()
+        SigningPhrasePopup().wait_until_appears().confirm_phrase()
+        account_popup = wallet.left_panel.open_add_account_popup()
+        account_popup.set_name(name).set_emoji(emoji).set_color(color).save()
+        AuthenticatePopup().wait_until_appears().authenticate(user_account.password)
+        account_popup.wait_until_hidden()
+
+    with step('Verify toast message notification when adding account'):
+        assert len(WalletToastMessage().get_toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = WalletToastMessage().get_toast_messages[0]
+        assert message == f'"{name}" successfully added'
+
+    with step('Verify that the account is correctly displayed in accounts list'):
+        expected_account = constants.user.account_list_item(name, color.lower(), emoji_unicode)
+        started_at = time.monotonic()
+        while expected_account not in wallet.left_panel.accounts:
+            time.sleep(1)
+            if time.monotonic() - started_at > 15:
+                raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
+
+    with step('Restart application'):
+        aut.restart()
+        main_screen.authorize_user(user_account)
+
+    with step('Add second generated wallet account'):
+        wallet = main_screen.left_panel.open_wallet()
+        assert not SigningPhrasePopup().is_ok_got_it_button_visible(), \
+            f"Signing phrase should not be present because it has been hidden in the first step"
+        account_popup = wallet.left_panel.open_add_account_popup()
+        account_popup.set_name(name2).set_emoji(emoji2).set_color(color2).save()
+        AuthenticatePopup().wait_until_appears().authenticate(user_account.password)
+        account_popup.wait_until_hidden()
+
+    with step('Verify toast message notification when adding account'):
+        assert len(WalletToastMessage().get_toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = WalletToastMessage().get_toast_messages[0]
+        assert message == f'"{name2}" successfully added'
+
+    with step('Verify that the account is correctly displayed in accounts list'):
+        expected_account = constants.user.account_list_item_2(name2, color2.lower(), emoji_unicode2)
+        started_at = time.monotonic()
+        while expected_account not in wallet.left_panel.accounts:
+            time.sleep(1)
+            if time.monotonic() - started_at > 15:
+                raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
+            


### PR DESCRIPTION
Fixes https://github.com/status-im/desktop-qa-automation/issues/238

Test case: https://ethstatus.testrail.net/index.php?/cases/view/704459

CI execution: https://ci.status.im/job/status-desktop/job/e2e/job/manual/724/

<img width="1840" alt="Screenshot 2023-10-31 at 21 58 34" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/de17e4b4-7de8-47c7-9935-7a4995928478">
