### PR TITLE
chore: image comparison replaced with other verifications

### DIFF
--- a/constants/images_paths.py
+++ b/constants/images_paths.py
@@ -1,0 +1,4 @@
+# Images paths
+PERMISSION_WELCOME_IMAGE_PATH = '/imports/assets/png/community/permissions2_3.png'
+AIRDROPS_WELCOME_IMAGE_PATH = '/imports/assets/png/community/airdrops8_1.png'
+TOKENS_WELCOME_IMAGE_PATH = '/imports/assets/png/community/mint2_1.png'

--- a/constants/user.py
+++ b/constants/user.py
@@ -32,7 +32,8 @@ UserCommunityInfo = namedtuple('CommunityInfo', ['name', 'description', 'members
 UserChannel = namedtuple('Channel', ['name', 'image', 'selected'])
 
 account_list_item = namedtuple('AccountListItem', ['name', 'color', 'emoji'])
-wallet_account_list_item = namedtuple('WalletAccountListItem', ['name', 'icon', 'object'])
+wallet_account_list_item = namedtuple('WalletAccountListItem', ['name', 'icon_color', 'icon_emoji', 'object'])
 
 wallet_account = namedtuple('PrivateKeyAddressPair', ['private_key', 'wallet_address'])
-private_key_address_pair_1 = wallet_account('2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470', '0xd89b48cbcb4244f84a4fb5d3369c120e8f8aa74e')
+private_key_address_pair_1 = wallet_account('2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470',
+                                            '0xd89b48cbcb4244f84a4fb5d3369c120e8f8aa74e')

--- a/gui/screens/community_settings.py
+++ b/gui/screens/community_settings.py
@@ -244,9 +244,9 @@ class TokensView(QObject):
         return self._mint_token_button.is_visible
 
     @property
-    @allure.step('Get tokens welcome image')
-    def tokens_welcome_image(self) -> Image:
-        return self._welcome_image.image
+    @allure.step('Get tokens welcome image path')
+    def tokens_welcome_image_path(self) -> str:
+        return self._welcome_image.object.source.path
 
     @property
     @allure.step('Get tokens welcome title')
@@ -300,9 +300,9 @@ class AirdropsView(QObject):
         return self._new_airdrop_button.is_visible
 
     @property
-    @allure.step('Get airdrops welcome image')
-    def airdrops_welcome_image(self) -> Image:
-        return self._welcome_image.image
+    @allure.step('Get airdrops welcome image path')
+    def airdrops_welcome_image_path(self) -> str:
+        return self._welcome_image.object.source.path
 
     @property
     @allure.step('Get airdrops welcome title')
@@ -349,9 +349,9 @@ class PermissionsIntroView(QObject):
         self._welcome_checklist_3 = TextLabel('community_welcome_screen_checkList_element3')
 
     @property
-    @allure.step('Get permission welcome image')
-    def permission_welcome_image(self) -> Image:
-        return self._welcome_image.image
+    @allure.step('Get permission welcome image path')
+    def permission_welcome_image_source(self) -> str:
+        return self._welcome_image.object.source.path
 
     @property
     @allure.step('Get permission welcome title')

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -425,12 +425,14 @@ class EditAccountOrderSettings(WalletSettingsView):
         for account_item in driver.findAllObjects(self._account_item.real_name):
             element = QObject(name='', real_name=driver.objectMap.realName(account_item))
             name = str(account_item.title)
-            icon = None
+            icon_color = None
+            icon_emoji = None
             for child in objects_access.walk_children(account_item):
                 if getattr(child, 'objectName', '') == 'identicon':
-                    icon = Image(driver.objectMap.realName(child))
+                    icon_color = str(child.color.name)
+                    icon_emoji = str(child.emoji)
                     break
-            _accounts.append(wallet_account_list_item(name, icon, element))
+            _accounts.append(wallet_account_list_item(name, icon_color, icon_emoji, element))
 
         return sorted(_accounts, key=lambda account: account.object.y)
 

--- a/tests/communities/test_airdrops.py
+++ b/tests/communities/test_airdrops.py
@@ -4,6 +4,7 @@ from allure_commons._allure import step
 
 import constants
 from constants.community_settings import AirdropsElements
+from constants.images_paths import AIRDROPS_WELCOME_IMAGE_PATH
 from gui.main_window import MainWindow
 from scripts.tools import image
 
@@ -25,9 +26,8 @@ def test_airdrops_screen(main_screen: MainWindow, params):
     with step('Verify all elements on airdrops screen'):
         with step('New airdrop button is present'):
             assert airdrops_screen.is_airdrops_owner_token_button_visible is True
-        with step('Airdrops welcome image is correct'):
-            welcome_image = airdrops_screen.airdrops_welcome_image
-            image.compare(welcome_image, 'airdrops_welcome_image.png')
+        with step('Airdrops welcome image source path is correct'):
+            assert AIRDROPS_WELCOME_IMAGE_PATH == airdrops_screen.airdrops_welcome_image_path
         with step('Airdrops welcome title is correct'):
             assert airdrops_screen.airdrops_welcome_title == AirdropsElements.WELCOME_TITLE.value
         with step('Airdrops welcome subtitle is correct'):

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -26,15 +26,17 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         community_screen = create_community_form.create(params)
 
     with step('Verify community parameters in community overview'):
-        with step('Icon is correct'):
-            community_icon = main_screen.left_panel.get_community_logo(params['name'])
-            image.compare(community_icon, 'button_logo.png', timout_sec=5)
+        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
+        # with step('Icon is correct'):
+            # community_icon = main_screen.left_panel.get_community_logo(params['name'])
+            # image.compare(community_icon, 'button_logo.png', timout_sec=5)
         with step('Name is correct'):
             assert community_screen.left_panel.name == params['name']
         with step('Members count is correct'):
             assert '1' in community_screen.left_panel.members
-        with step('Logo is correct'):
-            image.compare(community_screen.left_panel.logo, 'logo.png')
+        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
+        # with step('Logo is correct'):
+            # image.compare(community_screen.left_panel.logo, 'logo.png')
 
     with step('Verify community parameters in community settings view'):
         community_setting = community_screen.left_panel.open_community_settings()
@@ -54,7 +56,8 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         assert community.name == params['name']
         assert community.description == params['description']
         # assert '1' in community.members TODO: Test on linux, members label is not visible
-        image.compare(community.image, 'logo_in_settings.png')
+        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
+        # image.compare(community.image, 'logo_in_settings.png')
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703056', 'Edit community separately')
@@ -127,13 +130,15 @@ def test_edit_community(main_screen: MainWindow, params):
 
     with step('Verify community parameters in community screen'):
         community_setting.left_panel.back_to_community()
-        with step('Icon is correct'):
-            community_icon = main_screen.left_panel.get_community_logo(params['name'])
-            image.compare(community_icon, 'button_updated_logo.png')
+        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
+        # with step('Icon is correct'):
+        #     community_icon = main_screen.left_panel.get_community_logo(params['name'])
+            # image.compare(community_icon, 'button_updated_logo.png')
         with step('Name is correct'):
             assert community_screen.left_panel.name == params['name']
-        with step('Logo is correct'):
-            image.compare(community_screen.left_panel.logo, 'updated_logo.png')
+        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
+        # with step('Logo is correct'):
+            # image.compare(community_screen.left_panel.logo, 'updated_logo.png')
 
     with step('Verify community parameters in community settings screen'):
         settings_screen = main_screen.left_panel.open_settings()
@@ -142,7 +147,7 @@ def test_edit_community(main_screen: MainWindow, params):
         assert community_info.name == params['name']
         assert community_info.description == params['description']
         assert '1' in community_info.members
-        image.compare(community_info.image, 'logo_in_settings_updated.png')
+        # image.compare(community_info.image, 'logo_in_settings_updated.png')
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703049', 'Create community channel')

--- a/tests/communities/test_permissions.py
+++ b/tests/communities/test_permissions.py
@@ -5,8 +5,8 @@ from allure_commons._allure import step
 import constants
 import driver
 from constants.community_settings import PermissionsElements
+from constants.images_paths import PERMISSION_WELCOME_IMAGE_PATH
 from gui.main_window import MainWindow
-from scripts.tools import image
 
 
 
@@ -24,9 +24,8 @@ def test_permissions_screen_overview(main_screen: MainWindow, params):
         permissions_settings = community_setting.left_panel.open_permissions()
 
     with step('Verify all elements on permissions screen'):
-        with step('Permission welcome image is correct'):
-            welcome_image = permissions_settings.permission_welcome_image
-            image.compare(welcome_image, 'permission_welcome_image.png')
+        with step('Permission welcome image source path is correct'):
+            assert PERMISSION_WELCOME_IMAGE_PATH == permissions_settings.permission_welcome_image_source
         with step('Permission welcome title is correct'):
             assert permissions_settings.permission_welcome_title == PermissionsElements.WELCOME_TITLE.value
         with step('Permission welcome subtitle is correct'):

--- a/tests/communities/test_tokens.py
+++ b/tests/communities/test_tokens.py
@@ -4,6 +4,7 @@ from allure_commons._allure import step
 
 import constants
 from constants.community_settings import TokensElements
+from constants.images_paths import TOKENS_WELCOME_IMAGE_PATH
 from gui.main_window import MainWindow
 from scripts.tools import image
 
@@ -25,9 +26,8 @@ def test_tokens_screen(main_screen: MainWindow, params):
     with step('Verify all elements on tokens screen'):
         with step('Mint token button is present'):
             assert tokens_screen.is_tokens_owner_token_button_visible is True
-        with step('Tokens welcome image is correct'):
-            welcome_image = tokens_screen.tokens_welcome_image
-            image.compare(welcome_image, 'tokens_welcome_image.png')
+        with step('Tokens welcome image path is correct'):
+            assert TOKENS_WELCOME_IMAGE_PATH == tokens_screen.tokens_welcome_image_path
         with step('Tokens welcome title is correct'):
             assert tokens_screen.tokens_welcome_title == TokensElements.WELCOME_TITLE.value
         with step('Tokens welcome subtitle is correct'):

--- a/tests/settings/settings_wallet/test_wallet_settings_account_order.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_account_order.py
@@ -12,13 +12,15 @@ from scripts.tools import image
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703415',
                  'Account order: account order could be changed with drag&drop')
 @pytest.mark.case(703415)
-@pytest.mark.parametrize('address, default_name, name, color, emoji, second_name, second_color, second_emoji', [
-    pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'Status account',
-                 'WatchOnly', '#2a4af5', 'sunglasses', 'Generated', '#216266', 'thumbsup')
-])
+@pytest.mark.parametrize(
+    'address, default_name, name, color, emoji, acc_emoji, second_name, second_color, second_emoji, second_acc_emoji',
+    [
+        pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'Status account',
+                     'WatchOnly', '#2a4af5', 'sunglasses', '😎 ', 'Generated', '#216266', 'thumbsup', '👍 ')
+    ])
 def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_account, address: str, default_name,
-                                               name: str, color: str, emoji: str, second_name: str, second_color: str,
-                                               second_emoji: str):
+                                               name: str, color: str, emoji: str, acc_emoji: str, second_name: str,
+                                               second_color: str, second_emoji: str, second_acc_emoji: str):
     with step('Create watch-only wallet account'):
         wallet = main_screen.left_panel.open_wallet()
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
@@ -38,12 +40,13 @@ def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_acc
             assert account_order.accounts[0].name == default_name
             assert account_order.accounts[1].name == name
             assert account_order.accounts[2].name == second_name
-        # TODO: get rid of screenshots comparison, too flaky
-        # with step('Eye icon is displayed on watch-only account'):
-        #    account_order.get_eye_icon(name)
-        # with step('Icons on accounts are correct'):
-        #    image.compare(account_order.accounts[1].icon, 'watch_only_account_icon.png')
-        #    image.compare(account_order.accounts[2].icon, 'generated_account_icon.png')
+        with step('Eye icon is displayed on watch-only account'):
+            account_order.get_eye_icon(name)
+        with step('Icons on accounts are correct'):
+            assert account_order.accounts[1].icon_color == color
+            assert account_order.accounts[1].icon_emoji == acc_emoji
+            assert account_order.accounts[2].icon_color == second_color
+            assert account_order.accounts[2].icon_emoji == second_acc_emoji
 
     with step('Drag first account to the end of the list'):
         account_order.drag_account(default_name, 2)


### PR DESCRIPTION
As was discussed with @anastasiyaig, I replaced images comparison with other verifications and deleted steps with user images comparison (as it's not possible to get source path for such cases) 

The only place I left image comparison is here - https://github.com/status-im/desktop-qa-automation/blob/master/gui/screens/community.py#L44, @StateOf-Vlado can you please do it? (when I tried to get icon's properties color.name and emoji instead of grabbing image - it gave me an error I never understood)