### PR TITLE
Chore: improve emoji popup and syncing settings option selection

### DIFF
--- a/gui/components/emoji_popup.py
+++ b/gui/components/emoji_popup.py
@@ -6,9 +6,9 @@ from gui.elements.text_edit import TextEdit
 from .base_popup import BasePopup
 
 
-class EmojiPopup(BasePopup):
+class EmojiPopup(QObject):
     def __init__(self):
-        super(EmojiPopup, self).__init__()
+        super(EmojiPopup, self).__init__('mainWallet_AddEditAccountPopup_AccountEmojiSearchBox')
         self._search_text_edit = TextEdit('mainWallet_AddEditAccountPopup_AccountEmojiSearchBox')
         self._emoji_item = QObject('mainWallet_AddEditAccountPopup_AccountEmoji')
 
@@ -18,8 +18,14 @@ class EmojiPopup(BasePopup):
         return self
 
     @allure.step('Select emoji')
-    def select(self, name: str):
+    def select(self, name: str, attempts: int = 2):
         self._search_text_edit.text = name
         self._emoji_item.real_name['objectName'] = 'statusEmoji_' + name
-        self._emoji_item.click()
-        self._search_text_edit.wait_until_hidden()
+        try:
+            self._emoji_item.click()
+        except AssertionError as err:
+            if attempts:
+                return self.select(name, attempts - 1)
+            else:
+                raise err
+        EmojiPopup().wait_until_hidden()

--- a/gui/components/emoji_popup.py
+++ b/gui/components/emoji_popup.py
@@ -23,7 +23,7 @@ class EmojiPopup(QObject):
         self._emoji_item.real_name['objectName'] = 'statusEmoji_' + name
         try:
             self._emoji_item.click()
-        except AssertionError as err:
+        except LookupError as err:
             if attempts:
                 return self.select(name, attempts - 1)
             else:

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -54,9 +54,15 @@ class LeftPanel(QObject):
         return BackUpYourSeedPhrasePopUp()
 
     @allure.step('Open syncing settings')
-    def open_syncing_settings(self):
+    def open_syncing_settings(self, attempts: int = 2):
         self._open_settings('8-MainMenuItem')
-        return SyncingSettingsView()
+        try:
+            return SyncingSettingsView().wait_until_appears()
+        except AssertionError:
+            if attempts:
+                return self.open_syncing_settings(attempts - 1)
+            else:
+                raise f"Sync settings was not opened"
 
     @allure.step('Choose sign out and quit in settings')
     def sign_out_and_quit(self):

--- a/tests/wallet_main_screen/test_wallet_main_saved_addresses.py
+++ b/tests/wallet_main_screen/test_wallet_main_saved_addresses.py
@@ -7,8 +7,6 @@ import driver
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.main_window import MainWindow
 
-pytestmark = allure.suite("Wallet")
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703021', 'Manage a saved address')
 @pytest.mark.case(703021)


### PR DESCRIPTION
I made several commits to easier review. I also tested all my commits on poor Linux 03 which was initially causing problems

- EmojiPopUp improved to have a better init, as well as added attempts to select an emoji (there was a problem yesterday, that the test was not able to click / select an emoji , therefore it took 15 minutes for it to eventually fail)

CI run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/771/

<img width="2032" alt="Screenshot 2023-11-02 at 11 15 04" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/87f1471c-024c-48b0-a780-52dd979bbf50">

- improve selection of Syncing settings option, because I noticed today  the test was not able to click the option (but hovered it)

CI run https://ci.status.im/job/status-desktop/job/e2e/job/manual/772/

<img width="2032" alt="Screenshot 2023-11-02 at 11 28 42" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/85345d59-ecc8-4bef-8a4c-4362be9f6096">