### PR TITLE
chore: Mock keycard option added in start AUT

### DIFF
--- a/constants/aut_options.py
+++ b/constants/aut_options.py
@@ -1,0 +1,1 @@
+MOCK_KEYCARD = '--test-mode=1'

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -31,6 +31,7 @@ class AUT:
         self.app_data = configs.testpath.STATUS_DATA / f'app_{datetime.now():%H%M%S_%f}'
         if user_data is not None:
             user_data.copy_to(self.app_data / 'data')
+        self.options = ''
         driver.testSettings.setWrappersForApplication(self.aut_id, ['Qt'])
 
     def __str__(self):
@@ -76,7 +77,8 @@ class AUT:
             self.pid = None
 
     @allure.step("Start application")
-    def launch(self, attempt: int = 2) -> 'AUT':
+    def launch(self, options='', attempt: int = 2) -> 'AUT':
+        self.options = options
         try:
             self.port = local_system.find_free_port(configs.squish.AUT_PORT, 1000)
             if configs.ATTACH_MODE:
@@ -85,7 +87,8 @@ class AUT:
                     configs.testpath.SQUISH_DIR / 'bin' / 'startaut',
                     f'--port={self.port}',
                     f'"{self.path}"',
-                    f'-d={self.app_data}'
+                    f'-d={self.app_data}',
+                    options
                 ]
                 self.pid = local_system.execute(command)
             else:
@@ -101,7 +104,7 @@ class AUT:
             _logger.debug(err)
             self.stop()
             if attempt:
-                return self.launch(attempt-1)
+                return self.launch(options, attempt - 1)
             else:
                 raise err
 

--- a/fixtures/aut.py
+++ b/fixtures/aut.py
@@ -11,6 +11,13 @@ from scripts.utils.system_path import SystemPath
 
 
 @pytest.fixture
+def options(request):
+    if hasattr(request, 'param'):
+        return request.param
+    return ''
+
+
+@pytest.fixture
 def application_logs():
     yield
     if configs.testpath.STATUS_DATA.exists():
@@ -47,8 +54,8 @@ def multiple_instance():
 
 
 @pytest.fixture
-def main_window(aut: AUT, user_data):
-    aut.launch()
+def main_window(aut: AUT, user_data, options):
+    aut.launch(options)
     yield MainWindow().wait_until_appears().prepare()
     aut.stop()
 

--- a/gui/elements/button.py
+++ b/gui/elements/button.py
@@ -20,6 +20,6 @@ class Button(QObject):
     ):
         if None not in (x, y, button):
             getattr(self.object, 'clicked')()
+            _logger.info(f'{self}: clicked')
         else:
             super(Button, self).click(x, y, button)
-        _logger.info(f'{self}: clicked')

--- a/tests/settings/settings_keycard/test_create_keycard_account_with_new_seed_phrase.py
+++ b/tests/settings/settings_keycard/test_create_keycard_account_with_new_seed_phrase.py
@@ -4,7 +4,7 @@ from allure import step
 
 import configs
 import driver
-from constants import ColorCodes
+from constants import ColorCodes, aut_options
 from constants.keycard import Keycard
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController


### PR DESCRIPTION
#260
Test run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/795/

Example:
```
from constants import aut_options
@pytest.mark.parametrize('options', [aut_options.MOCK_KEYCARD])
def test_create_keycard_account_with_new_seed_phrase(main_screen: MainWindow):
    pass
```
