### PR TITLE
chore: add watched address test is now standalone and matches figma flow

### DIFF
--- a/constants/wallet.py
+++ b/constants/wallet.py
@@ -52,3 +52,7 @@ class WalletNetworkDefaultValues(Enum):
 class WalletEditNetworkErrorMessages(Enum):
     PINGUNSUCCESSFUL = 'RPC appears to be either offline or this is not a valid JSON RPC endpoint URL'
     PINGVERIFIED = 'RPC successfully reached'
+
+
+class WalletOrigin(Enum):
+    WATCHED_ADDRESS_ORIGIN = 'New watched address'

--- a/gui/components/wallet/authenticate_popup.py
+++ b/gui/components/wallet/authenticate_popup.py
@@ -23,3 +23,8 @@ class AuthenticatePopup(QObject):
                 self.authenticate(password, attempt - 1)
             else:
                 raise err
+
+    @allure.step('Check if authenticate button is present')
+    def is_authenticate_button_visible(self):
+        return self._primary_button.is_visible
+

--- a/gui/components/wallet/wallet_account_popups.py
+++ b/gui/components/wallet/wallet_account_popups.py
@@ -4,7 +4,7 @@ import typing
 import allure
 
 import configs
-import constants.wallet
+from constants.wallet import *
 import driver
 from gui.screens.settings_wallet import *
 from gui.components.base_popup import BasePopup
@@ -30,7 +30,7 @@ class AccountPopup(BasePopup):
         self._color_radiobutton = QObject('color_StatusColorRadioButton')
         # origin
         self._origin_combobox = QObject('mainWallet_AddEditAccountPopup_SelectedOrigin')
-        self._watch_only_account_origin_item = QObject("mainWallet_AddEditAccountPopup_OriginOptionWatchOnlyAcc")
+        self._watched_address_origin_item = QObject("mainWallet_AddEditAccountPopup_OriginOptionWatchOnlyAcc")
         self._new_master_key_origin_item = QObject('mainWallet_AddEditAccountPopup_OriginOptionNewMasterKey')
         self._existing_origin_item = QObject('addAccountPopup_OriginOption_StatusListItem')
         self._use_keycard_button = QObject('mainWallet_AddEditAccountPopup_MasterKey_GoToKeycardSettingsOption')
@@ -72,9 +72,10 @@ class AccountPopup(BasePopup):
         return self
 
     @allure.step('Set eth address for account added from plus button')
-    def set_origin_eth_address(self, value: str):
+    def set_origin_watched_address(self, value: str):
         self._origin_combobox.click()
-        self._watch_only_account_origin_item.click()
+        self._watched_address_origin_item.click()
+        assert self._origin_combobox.__getattr__('title') == WalletOrigin.WATCHED_ADDRESS_ORIGIN.value
         self._address_text_edit.text = value
         return self
 
@@ -110,7 +111,7 @@ class AccountPopup(BasePopup):
             del self._derivation_path_list_item.real_name['title']
             self._address_combobox_button.click()
             GeneratedAddressesList().wait_until_appears().select(index)
-            if value != constants.wallet.DerivationPath.ETHEREUM.value:
+            if value != DerivationPath.ETHEREUM.value:
                 self._scroll.vertical_scroll_to(self._non_eth_checkbox)
                 self._non_eth_checkbox.set(True)
         else:

--- a/tests/settings/settings_wallet/test_wallet_settings_account_order.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_account_order.py
@@ -23,7 +23,7 @@ def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_acc
         wallet = main_screen.left_panel.open_wallet()
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
-        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_eth_address(address).save()
+        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_watched_address(address).save()
         account_popup.wait_until_hidden()
 
     with step('Create generated wallet account'):

--- a/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
+++ b/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
@@ -43,46 +43,6 @@ def test_edit_default_wallet_account(main_screen: MainWindow, name: str, new_nam
                 raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
 
 
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703026', 'Manage a watch-only account')
-@pytest.mark.case(703026)
-@pytest.mark.parametrize('address, name, color, emoji, emoji_unicode, new_name, new_color,'
-                         'new_emoji, new_emoji_unicode', [
-                             pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
-                                          'sunglasses', '1f60e', 'AccWatch1edited', '#216266', 'thumbsup', '1f44d')
-                         ])
-def test_manage_watch_only_account(main_screen: MainWindow, address: str, color: str, emoji: str, emoji_unicode: str,
-                                   name: str, new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str):
-    with step('Create watch-only wallet account'):
-        wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
-        account_popup = wallet.left_panel.open_add_account_popup()
-        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_eth_address(address).save()
-        account_popup.wait_until_hidden()
-
-    with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
-            f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
-        assert message == f'"{name}" successfully added'
-
-    with step('Verify that the account is correctly displayed in accounts list'):
-        expected_account = constants.user.account_list_item(name, color.lower(), emoji_unicode)
-        started_at = time.monotonic()
-        while expected_account not in wallet.left_panel.accounts:
-            time.sleep(1)
-            if time.monotonic() - started_at > 15:
-                raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
-
-    with step('Delete wallet account'):
-        wallet.left_panel.delete_account_from_context_menu(name).confirm()
-
-    # TODO: add toast check for deletion when https://github.com/status-im/status-desktop/issues/12541 fixed
-
-    with step('Verify that the account is not displayed in accounts list'):
-        assert driver.waitFor(lambda: name not in [account.name for account in wallet.left_panel.accounts], 10000), \
-            f'Account with {name} is still displayed even it should not be'
-
-
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703026',
                  'Manage a watch-only account from context menu option')
 @pytest.mark.case(703026)

--- a/tests/wallet_main_screen/test_wlt_main_add_acc_manage_watched_address.py
+++ b/tests/wallet_main_screen/test_wlt_main_add_acc_manage_watched_address.py
@@ -1,0 +1,47 @@
+import time
+
+import allure
+import pytest
+from allure_commons._allure import step
+
+import constants
+import driver
+from gui.components.signing_phrase_popup import SigningPhrasePopup
+from gui.components.wallet.authenticate_popup import AuthenticatePopup
+from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.main_window import MainWindow
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703026', 'Manage a watch-only account')
+@pytest.mark.case(703026)
+@pytest.mark.parametrize('address, name, color, emoji, emoji_unicode', [
+    pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
+                 'sunglasses', '1f60e')
+])
+def test_wallet_add_acc_add_watched_address(
+        main_screen: MainWindow, address: str, color: str, emoji: str, emoji_unicode: str,
+        name: str):
+    with step('Add watched address with plus action button'):
+        wallet = main_screen.left_panel.open_wallet()
+        SigningPhrasePopup().wait_until_appears().confirm_phrase()
+        account_popup = wallet.left_panel.open_add_account_popup()
+        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_watched_address(address).save()
+        account_popup.wait_until_hidden()
+
+    with step('Check authentication popup does not appear'):
+        assert not AuthenticatePopup().is_authenticate_button_visible(), \
+            f"Authentication should not appear for adding watched addresses"
+
+    with step('Verify toast message notification when adding account'):
+        assert len(WalletToastMessage().get_toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = WalletToastMessage().get_toast_messages[0]
+        assert message == f'"{name}" successfully added'
+
+    with step('Verify that the account is correctly displayed in accounts list'):
+        expected_account = constants.user.account_list_item(name, color.lower(), emoji_unicode)
+        started_at = time.monotonic()
+        while expected_account not in wallet.left_panel.accounts:
+            time.sleep(1)
+            if time.monotonic() - started_at > 15:
+                raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')


### PR DESCRIPTION
Fixes https://github.com/status-im/desktop-qa-automation/issues/56
CI run https://ci.status.im/job/status-desktop/job/e2e/job/manual/788/

<img width="1840" alt="Screenshot 2023-11-03 at 19 05 37" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/64e85585-eb37-48a3-a7d6-691bced13aaf">


- Move the Add watched address to a separate file
- Added a small verification to origin option selected 
- Removed steps with deletion as i plan to cover differently 
- Added a verification for authentication button is not available for adding of watched addresses

**NOTE:** The delete functionality is still being checked in another test 