### PR TITLE
chore: managing accounts tests are having the toast verification for deletion

### DIFF
--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -60,7 +60,10 @@ def test_delete_generated_account_from_wallet_settings(
         delete_confirmation_popup = acc_view.click_remove_account_button()
         delete_confirmation_popup.click_remove_account_button()
 
-        # TODO: verification for account removal toast (after https://github.com/status-im/status-desktop/issues/12541)
+    with step('Verify toast message notification when removing account'):
+        messages = WalletToastMessage().get_toast_messages
+        assert f'"{account_name}" successfully removed' in messages, \
+            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify the removed account is not displayed in accounts list on main wallet screen'):
         wallet = main_screen.left_panel.open_wallet()
@@ -68,4 +71,3 @@ def test_delete_generated_account_from_wallet_settings(
         assert driver.waitFor(
             lambda: account_name not in [account.name for account in wallet.left_panel.accounts], 10000), \
             f'Account with {account_name} is still displayed even it should not be'
-        

--- a/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
+++ b/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
@@ -129,7 +129,10 @@ def test_manage_generated_account(main_screen: MainWindow, user_account,
     with step('Delete wallet account with agreement'):
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
-    # TODO: add toast check for deletion when https://github.com/status-im/status-desktop/issues/12541 fixed
+    with step('Verify toast message notification when removing account'):
+        messages = WalletToastMessage().get_toast_messages
+        assert f'"{new_name}" successfully removed' in messages, \
+            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that the account is not displayed in accounts list'):
         assert driver.waitFor(lambda: new_name not in [account.name for account in wallet.left_panel.accounts], 10000), \
@@ -175,7 +178,10 @@ def test_manage_custom_generated_account(main_screen: MainWindow, user_account,
     with step('Delete wallet account with agreement'):
         wallet.left_panel.delete_account_from_context_menu(name).agree_and_confirm()
 
-    # TODO: add toast check for deletion when https://github.com/status-im/status-desktop/issues/12541 fixed
+    with step('Verify toast message notification when removing account'):
+        messages = WalletToastMessage().get_toast_messages
+        assert f'"{name}" successfully removed' in messages, \
+            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that the account is not displayed in accounts list'):
         assert driver.waitFor(lambda: name not in [account.name for account in wallet.left_panel.accounts], 10000), \
@@ -240,7 +246,10 @@ def test_private_key_imported_account(main_screen: MainWindow, user_account, add
     with step('Delete wallet account'):
         wallet.left_panel.delete_account_from_context_menu(new_name).confirm()
 
-    # TODO: add toast check for deletion when https://github.com/status-im/status-desktop/issues/12541 fixed
+    with step('Verify toast message notification when removing account'):
+        messages = WalletToastMessage().get_toast_messages
+        assert f'"{new_name}" successfully removed' in messages, \
+            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that the account is not displayed in accounts list'):
         assert driver.waitFor(lambda: new_name not in [account.name for account in wallet.left_panel.accounts], 10000), \
@@ -306,7 +315,10 @@ def test_seed_phrase_imported_account(main_screen: MainWindow, user_account,
     with step('Delete wallet account with agreement'):
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
-    # TODO: add toast check for deletion when https://github.com/status-im/status-desktop/issues/12541 fixed
+    with step('Verify toast message notification when removing account'):
+        messages = WalletToastMessage().get_toast_messages
+        assert f'"{new_name}" successfully removed' in messages, \
+            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that the account is not displayed in accounts list'):
         assert driver.waitFor(lambda: new_name not in [account.name for account in wallet.left_panel.accounts], 10000), \
@@ -362,7 +374,10 @@ def test_seed_phrase_generated_account(main_screen: MainWindow, user_account,
     with step('Delete wallet account with agreement'):
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
-    # TODO: add toast check for deletion when https://github.com/status-im/status-desktop/issues/12541 fixed
+    with step('Verify toast message notification when removing account'):
+        messages = WalletToastMessage().get_toast_messages
+        assert f'"{new_name}" successfully removed' in messages, \
+            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that the account is not displayed in accounts list'):
         assert driver.waitFor(lambda: new_name not in [account.name for account in wallet.left_panel.accounts], 10000), \


### PR DESCRIPTION
Added checks for toasts when we delete accounts
Fixes https://github.com/status-im/desktop-qa-automation/issues/285

CI run https://ci.status.im/job/status-desktop/job/e2e/job/manual/848/

<img width="1840" alt="Screenshot 2023-11-10 at 11 24 57" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/fa7bc786-c476-45fd-b287-d9b1d639acac">

