### PR TITLE
chore: Dependence on Jenkins Job name removed in TestRail configs

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
     )
     string(
       name: 'TESTRAIL_RUN_NAME',
-      description: 'Test run ID in Test Rail.',
+      description: 'Test run name in Test Rail.',
       defaultValue: ''
     )
     /* FIXME: This is temporary and should be removed. */

--- a/configs/testrail.py
+++ b/configs/testrail.py
@@ -1,10 +1,8 @@
 import os
-from datetime import datetime
 
 CI_BUILD_URL = os.getenv('BUILD_URL', '')
-CI_NIGHTLY = True if 'nightly' in CI_BUILD_URL else False
 
-RUN_NAME = os.getenv('TESTRAIL_RUN_NAME', f'Nightly regression {datetime.now():%d.%m.%Y}' if CI_NIGHTLY else '')
+RUN_NAME = os.getenv('TESTRAIL_RUN_NAME', '')
 PROJECT_ID = os.getenv('TESTRAIL_PROJECT_ID', '')
 URL = os.getenv('TESTRAIL_URL', '')
 USR = os.getenv('TESTRAIL_USR', '')


### PR DESCRIPTION
#276
We will get the name of the test run from CI, so we don't need to generate a name
Will be resolved here: https://github.com/status-im/desktop-qa-automation/issues/276