### PR TITLE
ci: don't run on agents with desktop-e2e-old label

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.8.1'
 pipeline {
 
   agent {
-    label "${params.AGENT} && x86_64 && qt-5.15.2"
+    label "${params.AGENT} && x86_64 && qt-5.15.2 && !desktop-e2e-old"
   }
 
   parameters {


### PR DESCRIPTION
A temporary attempt to debug apparent delays possibly caused by running both old and new e2e tests on the same host.

Related to:
* https://github.com/status-im/status-desktop/pull/12697