### PR TITLE
chore: change locators for splash screens and divide them into 2

### DIFF
--- a/gui/components/onboarding/beta_consent_popup.py
+++ b/gui/components/onboarding/beta_consent_popup.py
@@ -3,19 +3,19 @@ import allure
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
 from gui.elements.check_box import CheckBox
+from gui.elements.object import QObject
 
 
-class BetaConsentPopup(BasePopup):
+class BetaConsentPopup(QObject):
 
     def __init__(self):
         self._agree_to_use_checkbox = CheckBox('agreeToUse_StatusCheckBox')
         self._ready_to_use_checkbox = CheckBox('readyToUse_StatusCheckBox')
         self._ready_to_use_button = Button('i_m_ready_to_use_Status_Desktop_Beta_StatusButton')
-        super(BetaConsentPopup, self).__init__()
+        super(BetaConsentPopup, self).__init__('desktopBetaStatusModal')
 
     @allure.step('Confirm all')
     def confirm(self):
         self._agree_to_use_checkbox.set(True)
         self._ready_to_use_checkbox.set(True)
         self._ready_to_use_button.click()
-        self.wait_until_hidden()

--- a/gui/components/splash_screen_did_u_know.py
+++ b/gui/components/splash_screen_did_u_know.py
@@ -1,13 +1,14 @@
 import allure
 
 import configs
+import driver
 from gui.elements.object import QObject
 
 
-class SplashScreen(QObject):
+class SplashScreenDidYouKnow(QObject):
 
     def __init__(self):
-        super(SplashScreen, self).__init__('splashScreen')
+        super(SplashScreenDidYouKnow, self).__init__('splashScreenDidYouKnow')
 
     @allure.step('Wait until appears {0}')
     def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
@@ -17,3 +18,4 @@ class SplashScreen(QObject):
     @allure.step('Wait until hidden {0}')
     def wait_until_hidden(self, timeout_msec: int = configs.timeouts.APP_LOAD_TIMEOUT_MSEC):
         super().wait_until_hidden(timeout_msec)
+

--- a/gui/components/splash_screen_main_loader.py
+++ b/gui/components/splash_screen_main_loader.py
@@ -1,0 +1,21 @@
+import allure
+
+import configs
+import driver
+from gui.elements.object import QObject
+
+
+class SplashScreenMainLoader(QObject):
+
+    def __init__(self):
+        super(SplashScreenMainLoader, self).__init__('splashScreenMainLoader')
+
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        assert self.wait_for(lambda: self.exists, timeout_msec), f'Object {self} is not visible'
+        return self
+
+    @allure.step('Wait until hidden {0}')
+    def wait_until_hidden(self, timeout_msec: int = configs.timeouts.APP_LOAD_TIMEOUT_MSEC):
+        super().wait_until_hidden(timeout_msec)
+        

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -10,7 +10,8 @@ from constants import UserAccount
 from gui.components.community.invite_contacts import InviteContactsPopup
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.components.user_canvas import UserCanvas
 from gui.elements.button import Button
 from gui.elements.object import QObject
@@ -150,7 +151,7 @@ class MainWindow(Window):
         confirm_password_view.confirm_password(user_account.password)
         if configs.system.IS_MAC:
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreen().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
         if not configs.DEV_BUILD:
             if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
                 BetaConsentPopup().confirm()
@@ -159,7 +160,7 @@ class MainWindow(Window):
     @allure.step('Log in user')
     def log_in(self, user_account: UserAccount):
         LoginView().log_in(user_account)
-        SplashScreen().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
         if not configs.DEV_BUILD:
             if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
                 BetaConsentPopup().confirm()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -10,7 +10,6 @@ from constants import UserAccount
 from gui.components.community.invite_contacts import InviteContactsPopup
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
 from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.components.user_canvas import UserCanvas
 from gui.elements.button import Button
@@ -151,16 +150,19 @@ class MainWindow(Window):
         confirm_password_view.confirm_password(user_account.password)
         if configs.system.IS_MAC:
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears()
+        #SplashScreenMainLoader().wait_until_hidden()
         if not configs.DEV_BUILD:
-            if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+            if not configs.DEV_BUILD:
+                BetaConsentPopup().wait_until_appears(60000)
                 BetaConsentPopup().confirm()
         return self
 
     @allure.step('Log in user')
     def log_in(self, user_account: UserAccount):
         LoginView().log_in(user_account)
-        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears()
+        #SplashScreenMainLoader().wait_until_hidden()
         if not configs.DEV_BUILD:
             if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
                 BetaConsentPopup().confirm()

--- a/gui/objects_map/component_names.py
+++ b/gui/objects_map/component_names.py
@@ -7,339 +7,676 @@ from .main_names import statusDesktop_mainWindow_overlay, statusDesktop_mainWind
 o_Flickable = {"container": statusDesktop_mainWindow_overlay, "type": "Flickable", "unnamed": 1, "visible": True}
 
 # Context Menu
-o_StatusListView = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListView", "unnamed": 1, "visible": True}
-
+o_StatusListView = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListView", "unnamed": 1,
+                    "visible": True}
 
 """ Onboarding """
 # Before you get started Popup
-acknowledge_checkbox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "acknowledgeCheckBox", "type": "StatusCheckBox", "visible": True}
-termsOfUseCheckBox_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName":"termsOfUseCheckBox", "type": "StatusCheckBox", "visible": True}
-getStartedStatusButton_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "getStartedStatusButton", "type": "StatusButton", "visible": True}
-termsOfUseLink_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "termsOfUseLink", "type": "StatusBaseText", "visible": True}
-privacyPolicyLink_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "privacyPolicyLink", "type": "StatusBaseText", "visible": True}
+acknowledge_checkbox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                        "objectName": "acknowledgeCheckBox", "type": "StatusCheckBox", "visible": True}
+termsOfUseCheckBox_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                     "objectName": "termsOfUseCheckBox", "type": "StatusCheckBox", "visible": True}
+getStartedStatusButton_StatusButton = {"container": statusDesktop_mainWindow_overlay,
+                                       "objectName": "getStartedStatusButton", "type": "StatusButton", "visible": True}
+termsOfUseLink_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "termsOfUseLink",
+                                 "type": "StatusBaseText", "visible": True}
+privacyPolicyLink_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "privacyPolicyLink",
+                                    "type": "StatusBaseText", "visible": True}
 
 # Back Up Your Seed Phrase Popup
 o_PopupItem = {"container": statusDesktop_mainWindow_overlay, "type": "PopupItem", "unnamed": 1, "visible": True}
-i_have_a_pen_and_paper_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "Acknowledgements_havePen", "type": "StatusCheckBox", "visible": True}
-i_know_where_I_ll_store_it_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "Acknowledgements_storeIt", "type": "StatusCheckBox", "visible": True}
-i_am_ready_to_write_down_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "Acknowledgements_writeDown", "type": "StatusCheckBox", "visible": True}
-not_Now_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
-confirm_Seed_Phrase_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_nextButton", "type": "StatusButton", "visible": True}
-backup_seed_phrase_popup_StatusSeedPhraseInput_placeholder = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmSeedPhrasePanel_StatusSeedPhraseInput_%WORD_NO%", "type": "StatusSeedPhraseInput", "visible": True}
-reveal_seed_phrase_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmSeedPhrasePanel_RevealSeedPhraseButton", "type": "StatusButton", "visible": True}
-blur_GaussianBlur = {"container": statusDesktop_mainWindow_overlay, "id": "blur", "type": "GaussianBlur", "unnamed": 1, "visible": True}
-confirmSeedPhrasePanel_StatusSeedPhraseInput = {"container": statusDesktop_mainWindow_overlay, "type": "StatusSeedPhraseInput", "visible": True}
-confirmFirstWord = {"container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_BackupSeedStepBase_confirmFirstWord", "type": "BackupSeedStepBase", "visible": True}
-confirmFirstWord_inputText = {"container": confirmFirstWord, "objectName": "BackupSeedStepBase_inputText", "type": "TextEdit", "visible": True}
-continue_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_nextButton", "type": "StatusButton", "visible": True}
-confirmSecondWord = {"container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_BackupSeedStepBase_confirmSecondWord", "type": "BackupSeedStepBase", "visible": True}
-confirmSecondWord_inputText = {"container": confirmSecondWord, "objectName": "BackupSeedStepBase_inputText", "type": "TextEdit", "visible": True}
-i_acknowledge_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmStoringSeedPhrasePanel_storeCheck", "type": "StatusCheckBox", "visible": True}
-completeAndDeleteSeedPhraseButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_completeAndDeleteSeedPhraseButton", "type": "StatusButton", "visible": True}
+i_have_a_pen_and_paper_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                         "objectName": "Acknowledgements_havePen", "type": "StatusCheckBox",
+                                         "visible": True}
+i_know_where_I_ll_store_it_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                             "objectName": "Acknowledgements_storeIt", "type": "StatusCheckBox",
+                                             "visible": True}
+i_am_ready_to_write_down_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                           "objectName": "Acknowledgements_writeDown", "type": "StatusCheckBox",
+                                           "visible": True}
+not_Now_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
+                        "unnamed": 1, "visible": True}
+confirm_Seed_Phrase_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                                    "objectName": "BackupSeedModal_nextButton", "type": "StatusButton", "visible": True}
+backup_seed_phrase_popup_StatusSeedPhraseInput_placeholder = {"container": statusDesktop_mainWindow_overlay,
+                                                              "objectName": "ConfirmSeedPhrasePanel_StatusSeedPhraseInput_%WORD_NO%",
+                                                              "type": "StatusSeedPhraseInput", "visible": True}
+reveal_seed_phrase_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                                   "objectName": "ConfirmSeedPhrasePanel_RevealSeedPhraseButton",
+                                   "type": "StatusButton", "visible": True}
+blur_GaussianBlur = {"container": statusDesktop_mainWindow_overlay, "id": "blur", "type": "GaussianBlur", "unnamed": 1,
+                     "visible": True}
+confirmSeedPhrasePanel_StatusSeedPhraseInput = {"container": statusDesktop_mainWindow_overlay,
+                                                "type": "StatusSeedPhraseInput", "visible": True}
+confirmFirstWord = {"container": statusDesktop_mainWindow_overlay,
+                    "objectName": "BackupSeedModal_BackupSeedStepBase_confirmFirstWord", "type": "BackupSeedStepBase",
+                    "visible": True}
+confirmFirstWord_inputText = {"container": confirmFirstWord, "objectName": "BackupSeedStepBase_inputText",
+                              "type": "TextEdit", "visible": True}
+continue_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                         "objectName": "BackupSeedModal_nextButton", "type": "StatusButton", "visible": True}
+confirmSecondWord = {"container": statusDesktop_mainWindow_overlay,
+                     "objectName": "BackupSeedModal_BackupSeedStepBase_confirmSecondWord", "type": "BackupSeedStepBase",
+                     "visible": True}
+confirmSecondWord_inputText = {"container": confirmSecondWord, "objectName": "BackupSeedStepBase_inputText",
+                               "type": "TextEdit", "visible": True}
+i_acknowledge_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                "objectName": "ConfirmStoringSeedPhrasePanel_storeCheck", "type": "StatusCheckBox",
+                                "visible": True}
+completeAndDeleteSeedPhraseButton = {"container": statusDesktop_mainWindow_overlay,
+                                     "objectName": "BackupSeedModal_completeAndDeleteSeedPhraseButton",
+                                     "type": "StatusButton", "visible": True}
 
 # Send Contact Request Popup
-contactRequest_ChatKey_Input = {"container": statusDesktop_mainWindow_overlay, "objectName": "SendContactRequestModal_ChatKey_Input", "type": "TextEdit"}
-contactRequest_SayWhoYouAre_Input = {"container": statusDesktop_mainWindow_overlay, "objectName": "SendContactRequestModal_SayWhoYouAre_Input", "type": "TextEdit"}
-contactRequest_Send_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "SendContactRequestModal_Send_Button", "type": "StatusButton"}
+contactRequest_ChatKey_Input = {"container": statusDesktop_mainWindow_overlay,
+                                "objectName": "SendContactRequestModal_ChatKey_Input", "type": "TextEdit"}
+contactRequest_SayWhoYouAre_Input = {"container": statusDesktop_mainWindow_overlay,
+                                     "objectName": "SendContactRequestModal_SayWhoYouAre_Input", "type": "TextEdit"}
+contactRequest_Send_Button = {"container": statusDesktop_mainWindow_overlay,
+                              "objectName": "SendContactRequestModal_Send_Button", "type": "StatusButton"}
 
 # Change Language Popup
-close_the_app_now_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+close_the_app_now_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                                  "type": "StatusButton", "unnamed": 1, "visible": True}
 
 # User Status Profile Menu
-o_StatusListView = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListView", "unnamed": 1, "visible": True}
-userContextmenu_AlwaysActiveButton= {"container": o_StatusListView, "objectName": "userStatusMenuAlwaysOnlineAction", "type": "StatusMenuItem", "visible": True}
-userContextmenu_InActiveButton= {"container": o_StatusListView, "objectName": "userStatusMenuInactiveAction", "type": "StatusMenuItem", "visible": True}
-userContextmenu_AutomaticButton= {"container": o_StatusListView, "objectName": "userStatusMenuAutomaticAction", "type": "StatusMenuItem", "visible": True}
-userContextMenu_ViewMyProfileAction = {"container": o_StatusListView, "objectName": "userStatusViewMyProfileAction", "type": "StatusMenuItem", "visible": True}
+o_StatusListView = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListView", "unnamed": 1,
+                    "visible": True}
+userContextmenu_AlwaysActiveButton = {"container": o_StatusListView, "objectName": "userStatusMenuAlwaysOnlineAction",
+                                      "type": "StatusMenuItem", "visible": True}
+userContextmenu_InActiveButton = {"container": o_StatusListView, "objectName": "userStatusMenuInactiveAction",
+                                  "type": "StatusMenuItem", "visible": True}
+userContextmenu_AutomaticButton = {"container": o_StatusListView, "objectName": "userStatusMenuAutomaticAction",
+                                   "type": "StatusMenuItem", "visible": True}
+userContextMenu_ViewMyProfileAction = {"container": o_StatusListView, "objectName": "userStatusViewMyProfileAction",
+                                       "type": "StatusMenuItem", "visible": True}
 userLabel_StyledText = {"container": o_StatusListView, "type": "StyledText", "unnamed": 1, "visible": True}
 o_StatusIdenticonRing = {"container": o_StatusListView, "type": "StatusIdenticonRing", "unnamed": 1, "visible": True}
 
 # My Profile Popup
-ProfileHeader_userImage = {"container": statusDesktop_mainWindow_overlay, "objectName": "ProfileDialog_userImage", "type": "UserImage", "visible": True}
-ProfilePopup_displayName = {"container": statusDesktop_mainWindow_overlay, "objectName": "ProfileDialog_displayName", "type": "StatusBaseText", "visible": True}
-ProfilePopup_editButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "editProfileButton", "type": "StatusButton", "visible": True}
-ProfilePopup_SendContactRequestButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "profileDialog_sendContactRequestButton", "type": "StatusButton", "visible": True}
-profileDialog_userEmojiHash_EmojiHash = {"container": statusDesktop_mainWindow_overlay, "objectName": "ProfileDialog_userEmojiHash", "type": "EmojiHash", "visible": True}
-edit_TextEdit = {"container": statusDesktop_mainWindow_overlay, "id": "edit", "type": "TextEdit", "unnamed": 1, "visible": True}
+ProfileHeader_userImage = {"container": statusDesktop_mainWindow_overlay, "objectName": "ProfileDialog_userImage",
+                           "type": "UserImage", "visible": True}
+ProfilePopup_displayName = {"container": statusDesktop_mainWindow_overlay, "objectName": "ProfileDialog_displayName",
+                            "type": "StatusBaseText", "visible": True}
+ProfilePopup_editButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "editProfileButton",
+                           "type": "StatusButton", "visible": True}
+ProfilePopup_SendContactRequestButton = {"container": statusDesktop_mainWindow_overlay,
+                                         "objectName": "profileDialog_sendContactRequestButton", "type": "StatusButton",
+                                         "visible": True}
+profileDialog_userEmojiHash_EmojiHash = {"container": statusDesktop_mainWindow_overlay,
+                                         "objectName": "ProfileDialog_userEmojiHash", "type": "EmojiHash",
+                                         "visible": True}
+edit_TextEdit = {"container": statusDesktop_mainWindow_overlay, "id": "edit", "type": "TextEdit", "unnamed": 1,
+                 "visible": True}
 https_status_app_StatusBaseText = {"container": edit_TextEdit, "type": "StatusBaseText", "unnamed": 1, "visible": True}
-copy_icon_StatusIcon = {"container": statusDesktop_mainWindow_overlay, "objectName": "copy-icon", "type": "StatusIcon", "visible": True}
-
+copy_icon_StatusIcon = {"container": statusDesktop_mainWindow_overlay, "objectName": "copy-icon", "type": "StatusIcon",
+                        "visible": True}
 
 # Welcome Status Popup
-agreeToUse_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "agreeToUse", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
-readyToUse_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "readyToUse", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
-i_m_ready_to_use_Status_Desktop_Beta_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
-
+agreeToUse_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "desktopBetaAgreeCheckBox",
+                             "type": "StatusCheckBox", "visible": True}
+readyToUse_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "desktopBetaReadyCheckBox",
+                             "type": "StatusCheckBox", "visible": True}
+i_m_ready_to_use_Status_Desktop_Beta_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "desktopBetaStatusButton",
+                                                     "type": "StatusButton"}
+desktopBetaStatusModal = {"container": statusDesktop_mainWindow_overlay, "objectName": "desktopBetaStatusModal",
+                          "type": "StatusModal"}
 
 """ Communities """
 
 # Create Community Banner
-create_new_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "communityBannerButton", "type": "StatusButton", "visible": True}
+create_new_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                           "objectName": "communityBannerButton", "type": "StatusButton", "visible": True}
 
 # Create Community Popup
-createCommunityNameInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityNameInput", "type": "TextEdit", "visible": True}
-createCommunityDescriptionInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityDescriptionInput", "type": "TextEdit", "visible": True}
-communityBannerPicker_BannerPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityBannerPicker", "type": "BannerPicker", "visible": True}
-addButton_StatusRoundButton = {"container": communityBannerPicker_BannerPicker, "id": "addButton", "type": "StatusRoundButton", "unnamed": 1, "visible": True}
-communityLogoPicker_LogoPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityLogoPicker", "type": "LogoPicker", "visible": True}
-addButton_StatusRoundButton2 = {"container": communityLogoPicker_LogoPicker, "id": "addButton", "type": "StatusRoundButton", "unnamed": 1, "visible": True}
-communityColorPicker_ColorPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPicker", "type": "ColorPicker", "visible": True}
-StatusPickerButton = {"checkable": False, "container": communityColorPicker_ColorPicker, "type": "StatusPickerButton", "unnamed": 1, "visible": True}
-communityTagsPicker_TagsPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityTagsPicker", "type": "TagsPicker", "visible": True}
-choose_tags_StatusPickerButton = {"checkable": False, "container": communityTagsPicker_TagsPicker, "type": "StatusPickerButton", "unnamed": 1, "visible": True}
-archiveSupportToggle_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "archiveSupportToggle", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
-requestToJoinToggle_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "requestToJoinToggle", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
-pinMessagesToggle_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "pinMessagesToggle", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
-createCommunityNextBtn_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityNextBtn", "type": "StatusButton", "visible": True}
-createCommunityIntroMessageInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityIntroMessageInput", "type": "TextEdit", "visible": True}
-createCommunityOutroMessageInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityOutroMessageInput", "type": "TextEdit", "visible": True}
-createCommunityFinalBtn_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityFinalBtn", "type": "StatusButton", "visible": True}
+createCommunityNameInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityNameInput",
+                                     "type": "TextEdit", "visible": True}
+createCommunityDescriptionInput_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                            "objectName": "communityDescriptionInput", "type": "TextEdit",
+                                            "visible": True}
+communityBannerPicker_BannerPicker = {"container": statusDesktop_mainWindow_overlay,
+                                      "objectName": "communityBannerPicker", "type": "BannerPicker", "visible": True}
+addButton_StatusRoundButton = {"container": communityBannerPicker_BannerPicker, "id": "addButton",
+                               "type": "StatusRoundButton", "unnamed": 1, "visible": True}
+communityLogoPicker_LogoPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityLogoPicker",
+                                  "type": "LogoPicker", "visible": True}
+addButton_StatusRoundButton2 = {"container": communityLogoPicker_LogoPicker, "id": "addButton",
+                                "type": "StatusRoundButton", "unnamed": 1, "visible": True}
+communityColorPicker_ColorPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPicker",
+                                    "type": "ColorPicker", "visible": True}
+StatusPickerButton = {"checkable": False, "container": communityColorPicker_ColorPicker, "type": "StatusPickerButton",
+                      "unnamed": 1, "visible": True}
+communityTagsPicker_TagsPicker = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityTagsPicker",
+                                  "type": "TagsPicker", "visible": True}
+choose_tags_StatusPickerButton = {"checkable": False, "container": communityTagsPicker_TagsPicker,
+                                  "type": "StatusPickerButton", "unnamed": 1, "visible": True}
+archiveSupportToggle_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                       "id": "archiveSupportToggle", "type": "StatusCheckBox", "unnamed": 1,
+                                       "visible": True}
+requestToJoinToggle_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                      "id": "requestToJoinToggle", "type": "StatusCheckBox", "unnamed": 1,
+                                      "visible": True}
+pinMessagesToggle_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                    "id": "pinMessagesToggle", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
+createCommunityNextBtn_StatusButton = {"container": statusDesktop_mainWindow_overlay,
+                                       "objectName": "createCommunityNextBtn", "type": "StatusButton", "visible": True}
+createCommunityIntroMessageInput_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                             "objectName": "createCommunityIntroMessageInput", "type": "TextEdit",
+                                             "visible": True}
+createCommunityOutroMessageInput_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                             "objectName": "createCommunityOutroMessageInput", "type": "TextEdit",
+                                             "visible": True}
+createCommunityFinalBtn_StatusButton = {"container": statusDesktop_mainWindow_overlay,
+                                        "objectName": "createCommunityFinalBtn", "type": "StatusButton",
+                                        "visible": True}
 
 # Community Channel Popup:
-createOrEditCommunityChannelNameInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "createOrEditCommunityChannelNameInput", "type": "TextEdit", "visible": True}
-createOrEditCommunityChannelDescriptionInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "createOrEditCommunityChannelDescriptionInput", "type": "TextEdit", "visible": True}
-createOrEditCommunityChannelBtn_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "createOrEditCommunityChannelBtn", "type": "StatusButton", "visible": True}
-createOrEditCommunityChannel_EmojiButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "StatusChannelPopup_emojiButton", "type": "StatusRoundButton", "visible": True}
+createOrEditCommunityChannelNameInput_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                                  "objectName": "createOrEditCommunityChannelNameInput",
+                                                  "type": "TextEdit", "visible": True}
+createOrEditCommunityChannelDescriptionInput_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                                         "objectName": "createOrEditCommunityChannelDescriptionInput",
+                                                         "type": "TextEdit", "visible": True}
+createOrEditCommunityChannelBtn_StatusButton = {"container": statusDesktop_mainWindow_overlay,
+                                                "objectName": "createOrEditCommunityChannelBtn", "type": "StatusButton",
+                                                "visible": True}
+createOrEditCommunityChannel_EmojiButton = {"container": statusDesktop_mainWindow_overlay,
+                                            "objectName": "StatusChannelPopup_emojiButton", "type": "StatusRoundButton",
+                                            "visible": True}
 
 # Invite Contacts Popup
-communityProfilePopupInviteFrindsPanel = {"container": statusDesktop_mainWindow_overlay, "objectName": "CommunityProfilePopupInviteFrindsPanel_ColumnLayout", "type": "ProfilePopupInviteFriendsPanel", "visible": True}
-communityProfilePopupInviteMessagePanel = {"container": statusDesktop_mainWindow_overlay, "objectName": "CommunityProfilePopupInviteMessagePanel_ColumnLayout", "type": "ProfilePopupInviteMessagePanel", "visible": True}
-o_StatusMemberListItem = {"container": communityProfilePopupInviteFrindsPanel, "type": "StatusMemberListItem", "unnamed": 1, "visible": True}
-next_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "InviteFriendsToCommunityPopup_NextButton", "text": "Next", "type": "StatusButton", "visible": True}
-communityProfilePopupInviteMessagePanel_MessageInput_TextEdit = {"container": communityProfilePopupInviteMessagePanel, "objectName": "CommunityProfilePopupInviteMessagePanel_MessageInput", "type": "TextEdit", "visible": True}
-send_1_invite_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "InviteFriendsToCommunityPopup_SendButton", "text": "Send 1 invite", "type": "StatusButton", "visible": True}
-o_StatusMemberListItem_2 = {"container": communityProfilePopupInviteMessagePanel, "type": "StatusMemberListItem", "unnamed": 1, "visible": True}
+communityProfilePopupInviteFrindsPanel = {"container": statusDesktop_mainWindow_overlay,
+                                          "objectName": "CommunityProfilePopupInviteFrindsPanel_ColumnLayout",
+                                          "type": "ProfilePopupInviteFriendsPanel", "visible": True}
+communityProfilePopupInviteMessagePanel = {"container": statusDesktop_mainWindow_overlay,
+                                           "objectName": "CommunityProfilePopupInviteMessagePanel_ColumnLayout",
+                                           "type": "ProfilePopupInviteMessagePanel", "visible": True}
+o_StatusMemberListItem = {"container": communityProfilePopupInviteFrindsPanel, "type": "StatusMemberListItem",
+                          "unnamed": 1, "visible": True}
+next_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                     "objectName": "InviteFriendsToCommunityPopup_NextButton", "text": "Next", "type": "StatusButton",
+                     "visible": True}
+communityProfilePopupInviteMessagePanel_MessageInput_TextEdit = {"container": communityProfilePopupInviteMessagePanel,
+                                                                 "objectName": "CommunityProfilePopupInviteMessagePanel_MessageInput",
+                                                                 "type": "TextEdit", "visible": True}
+send_1_invite_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                              "objectName": "InviteFriendsToCommunityPopup_SendButton", "text": "Send 1 invite",
+                              "type": "StatusButton", "visible": True}
+o_StatusMemberListItem_2 = {"container": communityProfilePopupInviteMessagePanel, "type": "StatusMemberListItem",
+                            "unnamed": 1, "visible": True}
 
 # Welcome community
-headerTitle_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle", "type": "StatusBaseText", "visible": True}
-image_StatusImage = {"container": statusDesktop_mainWindow_overlay, "id": "image", "type": "StatusImage", "unnamed": 1, "visible": True}
-intro_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "text": "Intro", "type": "StatusBaseText", "unnamed": 1, "visible": True}
-select_addresses_to_share_StatusFlatButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusFlatButton", "unnamed": 1, "visible": True}
-join_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+headerTitle_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle",
+                              "type": "StatusBaseText", "visible": True}
+image_StatusImage = {"container": statusDesktop_mainWindow_overlay, "id": "image", "type": "StatusImage", "unnamed": 1,
+                     "visible": True}
+intro_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "text": "Intro", "type": "StatusBaseText",
+                        "unnamed": 1, "visible": True}
+select_addresses_to_share_StatusFlatButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                                              "type": "StatusFlatButton", "unnamed": 1, "visible": True}
+join_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
+                     "unnamed": 1, "visible": True}
 
 """ Settings """
 
 # Send Contact Request
-sendContactRequestModal_ChatKey_Input_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "SendContactRequestModal_ChatKey_Input", "type": "TextEdit", "visible": True}
-sendContactRequestModal_SayWhoYouAre_Input_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "SendContactRequestModal_SayWhoYouAre_Input", "type": "TextEdit", "visible": True}
-send_Contact_Request_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "SendContactRequestModal_Send_Button", "type": "StatusButton", "visible": True}
-
-
+sendContactRequestModal_ChatKey_Input_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                                  "objectName": "SendContactRequestModal_ChatKey_Input",
+                                                  "type": "TextEdit", "visible": True}
+sendContactRequestModal_SayWhoYouAre_Input_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                                       "objectName": "SendContactRequestModal_SayWhoYouAre_Input",
+                                                       "type": "TextEdit", "visible": True}
+send_Contact_Request_StatusButton = {"container": statusDesktop_mainWindow_overlay,
+                                     "objectName": "SendContactRequestModal_Send_Button", "type": "StatusButton",
+                                     "visible": True}
 
 """ Common """
 
 edit_TextEdit = {"container": statusDesktop_mainWindow_overlay, "type": "TextEdit", "unnamed": 1, "visible": True}
 
 # Select Color Popup
-communitySettings_ColorPanel_HexColor_Input = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPanelHexInput", "type": "TextEdit", "visible": True}
-communitySettings_SaveColor_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPanelSelectColorButton", "type": "StatusButton", "visible": True}
+communitySettings_ColorPanel_HexColor_Input = {"container": statusDesktop_mainWindow_overlay,
+                                               "objectName": "communityColorPanelHexInput", "type": "TextEdit",
+                                               "visible": True}
+communitySettings_SaveColor_Button = {"container": statusDesktop_mainWindow_overlay,
+                                      "objectName": "communityColorPanelSelectColorButton", "type": "StatusButton",
+                                      "visible": True}
 
 # Select Tag Popup
-o_StatusCommunityTag = {"container": statusDesktop_mainWindow_overlay, "type": "StatusCommunityTag", "unnamed": 1, "visible": True}
-confirm_Community_Tags_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+o_StatusCommunityTag = {"container": statusDesktop_mainWindow_overlay, "type": "StatusCommunityTag", "unnamed": 1,
+                        "visible": True}
+confirm_Community_Tags_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                                       "type": "StatusButton", "unnamed": 1, "visible": True}
 
 # Signing phrase popup
-signPhrase_Ok_Button = {"container": statusDesktop_mainWindow, "type": "StatusFlatButton", "objectName": "signPhraseModalOkButton", "visible": True}
+signPhrase_Ok_Button = {"container": statusDesktop_mainWindow, "type": "StatusFlatButton",
+                        "objectName": "signPhraseModalOkButton", "visible": True}
 
 # Remove account popup:
-mainWallet_Remove_Account_Popup_Account_Notification = {"container": statusDesktop_mainWindow, "objectName": "RemoveAccountPopup-Notification", "type": "StatusBaseText", "visible": True}
-mainWallet_Remove_Account_Popup_Account_Path_Component = {"container": statusDesktop_mainWindow, "objectName": "RemoveAccountPopup-DerivationPath", "type": "StatusInput", "visible": True}
-mainWallet_Remove_Account_Popup_Account_Path = {"container": mainWallet_Remove_Account_Popup_Account_Path_Component, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_Remove_Account_Popup_HavePenPaperCheckBox = {"checkable": True, "container": statusDesktop_mainWindow, "objectName": "RemoveAccountPopup-HavePenPaper", "type": "StatusCheckBox", "visible": True}
-mainWallet_Remove_Account_Popup_ConfirmButton = {"container": statusDesktop_mainWindow, "objectName": "RemoveAccountPopup-ConfirmButton", "type": "StatusButton", "visible": True}
-mainWallet_Remove_Account_Popup_CancelButton = {"container": statusDesktop_mainWindow, "objectName": "RemoveAccountPopup-CancelButton", "type": "StatusFlatButton", "visible": True}
+mainWallet_Remove_Account_Popup_Account_Notification = {"container": statusDesktop_mainWindow,
+                                                        "objectName": "RemoveAccountPopup-Notification",
+                                                        "type": "StatusBaseText", "visible": True}
+mainWallet_Remove_Account_Popup_Account_Path_Component = {"container": statusDesktop_mainWindow,
+                                                          "objectName": "RemoveAccountPopup-DerivationPath",
+                                                          "type": "StatusInput", "visible": True}
+mainWallet_Remove_Account_Popup_Account_Path = {"container": mainWallet_Remove_Account_Popup_Account_Path_Component,
+                                                "type": "TextEdit", "unnamed": 1, "visible": True}
+mainWallet_Remove_Account_Popup_HavePenPaperCheckBox = {"checkable": True, "container": statusDesktop_mainWindow,
+                                                        "objectName": "RemoveAccountPopup-HavePenPaper",
+                                                        "type": "StatusCheckBox", "visible": True}
+mainWallet_Remove_Account_Popup_ConfirmButton = {"container": statusDesktop_mainWindow,
+                                                 "objectName": "RemoveAccountPopup-ConfirmButton",
+                                                 "type": "StatusButton", "visible": True}
+mainWallet_Remove_Account_Popup_CancelButton = {"container": statusDesktop_mainWindow,
+                                                "objectName": "RemoveAccountPopup-CancelButton",
+                                                "type": "StatusFlatButton", "visible": True}
 
 # Add saved address popup
-mainWallet_Saved_Addreses_Popup_Name_Input = {"container": statusDesktop_mainWindow, "objectName": "savedAddressNameInput", "type": "TextEdit"}
-mainWallet_Saved_Addreses_Popup_Address_Input = {"container": statusDesktop_mainWindow, "objectName": "savedAddressAddressInput", "type": "StatusInput"}
-mainWallet_Saved_Addreses_Popup_Address_Input_Edit = {"container": statusDesktop_mainWindow, "objectName": "savedAddressAddressInputEdit", "type": "TextEdit"}
-mainWallet_Saved_Addreses_Popup_Address_Add_Button = {"container": statusDesktop_mainWindow, "objectName": "addSavedAddress", "type": "StatusButton"}
-mainWallet_Saved_Addreses_Popup_Add_Network_Selector = {"container": statusDesktop_mainWindow, "objectName": "addSavedAddressNetworkSelector", "type": "StatusNetworkSelector", "visible": True}
-mainWallet_Saved_Addreses_Popup_Add_Network_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "addNetworkTagItemButton", "type": "StatusRoundButton", "visible": True}
-mainWallet_Saved_Addreses_Popup_Add_Network_Selector_Tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectorTag", "type": "StatusNetworkListItemTag"}
-mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Mainnet_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Mainnet", "type": "StatusCheckBox", "visible": True}
-mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Optimism_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Optimism", "type": "StatusCheckBox", "visible": True}
-mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Arbitrum_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Arbitrum", "type": "StatusCheckBox", "visible": True}
-mainWallet_Saved_Addresses_Popup_Network_Selector_Mainnet_network_tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkTagRectangle_Mainnet", "type": "Rectangle", "visible": True}
-mainWallet_Saved_Addresses_Popup_Network_Selector_Optimism_network_tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkTagRectangle_Optimism", "type": "Rectangle", "visible": True}
-mainWallet_Saved_Addresses_Popup_Network_Selector_Arbitrum_network_tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkTagRectangle_Arbitrum", "type": "Rectangle", "visible": True}
+mainWallet_Saved_Addreses_Popup_Name_Input = {"container": statusDesktop_mainWindow,
+                                              "objectName": "savedAddressNameInput", "type": "TextEdit"}
+mainWallet_Saved_Addreses_Popup_Address_Input = {"container": statusDesktop_mainWindow,
+                                                 "objectName": "savedAddressAddressInput", "type": "StatusInput"}
+mainWallet_Saved_Addreses_Popup_Address_Input_Edit = {"container": statusDesktop_mainWindow,
+                                                      "objectName": "savedAddressAddressInputEdit", "type": "TextEdit"}
+mainWallet_Saved_Addreses_Popup_Address_Add_Button = {"container": statusDesktop_mainWindow,
+                                                      "objectName": "addSavedAddress", "type": "StatusButton"}
+mainWallet_Saved_Addreses_Popup_Add_Network_Selector = {"container": statusDesktop_mainWindow,
+                                                        "objectName": "addSavedAddressNetworkSelector",
+                                                        "type": "StatusNetworkSelector", "visible": True}
+mainWallet_Saved_Addreses_Popup_Add_Network_Button = {"container": statusDesktop_mainWindow_overlay,
+                                                      "objectName": "addNetworkTagItemButton",
+                                                      "type": "StatusRoundButton", "visible": True}
+mainWallet_Saved_Addreses_Popup_Add_Network_Selector_Tag = {"container": statusDesktop_mainWindow_overlay,
+                                                            "objectName": "networkSelectorTag",
+                                                            "type": "StatusNetworkListItemTag"}
+mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Mainnet_checkbox = {"container": statusDesktop_mainWindow_overlay,
+                                                                          "objectName": "networkSelectionCheckbox_Mainnet",
+                                                                          "type": "StatusCheckBox", "visible": True}
+mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Optimism_checkbox = {
+    "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Optimism",
+    "type": "StatusCheckBox", "visible": True}
+mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Arbitrum_checkbox = {
+    "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Arbitrum",
+    "type": "StatusCheckBox", "visible": True}
+mainWallet_Saved_Addresses_Popup_Network_Selector_Mainnet_network_tag = {"container": statusDesktop_mainWindow_overlay,
+                                                                         "objectName": "networkTagRectangle_Mainnet",
+                                                                         "type": "Rectangle", "visible": True}
+mainWallet_Saved_Addresses_Popup_Network_Selector_Optimism_network_tag = {"container": statusDesktop_mainWindow_overlay,
+                                                                          "objectName": "networkTagRectangle_Optimism",
+                                                                          "type": "Rectangle", "visible": True}
+mainWallet_Saved_Addresses_Popup_Network_Selector_Arbitrum_network_tag = {"container": statusDesktop_mainWindow_overlay,
+                                                                          "objectName": "networkTagRectangle_Arbitrum",
+                                                                          "type": "Rectangle", "visible": True}
 
 # Context Menu
-contextMenu_PopupItem = {"container": statusDesktop_mainWindow_overlay, "type": "PopupItem", "unnamed": 1, "visible": True}
-contextMenuItem = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1, "visible": True}
-contextMenuItem_AddWatchOnly = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": RegularExpression("AccountMenu-AddWatchOnlyAccountAction*"), "type": "StatusMenuItem"}
-contextMenuItem_Delete = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": RegularExpression("AccountMenu-DeleteAction*"), "type": "StatusMenuItem"}
-contextMenuItem_Edit = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": RegularExpression("AccountMenu-EditAction*"), "type": "StatusMenuItem"}
-contextMenuItem_HideInclude = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": RegularExpression("AccountMenu-HideFromTotalBalance*"), "type": "StatusMenuItem"}
+contextMenu_PopupItem = {"container": statusDesktop_mainWindow_overlay, "type": "PopupItem", "unnamed": 1,
+                         "visible": True}
+contextMenuItem = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1,
+                   "visible": True}
+contextMenuItem_AddWatchOnly = {"container": statusDesktop_mainWindow_overlay, "enabled": True,
+                                "objectName": RegularExpression("AccountMenu-AddWatchOnlyAccountAction*"),
+                                "type": "StatusMenuItem"}
+contextMenuItem_Delete = {"container": statusDesktop_mainWindow_overlay, "enabled": True,
+                          "objectName": RegularExpression("AccountMenu-DeleteAction*"), "type": "StatusMenuItem"}
+contextMenuItem_Edit = {"container": statusDesktop_mainWindow_overlay, "enabled": True,
+                        "objectName": RegularExpression("AccountMenu-EditAction*"), "type": "StatusMenuItem"}
+contextMenuItem_HideInclude = {"container": statusDesktop_mainWindow_overlay, "enabled": True,
+                               "objectName": RegularExpression("AccountMenu-HideFromTotalBalance*"),
+                               "type": "StatusMenuItem"}
 
 # Confirmation Popup
-confirmButton = {"container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("confirm*"), "type": "StatusButton"}
+confirmButton = {"container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("confirm*"),
+                 "type": "StatusButton"}
 
 # Picture Edit Popup
 o_StatusSlider = {"container": statusDesktop_mainWindow_overlay, "type": "StatusSlider", "unnamed": 1, "visible": True}
-cropSpaceItem_Item = {"container": statusDesktop_mainWindow_overlay, "id": "cropSpaceItem", "type": "Item", "unnamed": 1, "visible": True}
-make_picture_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "imageCropperAcceptButton", "type": "StatusButton", "visible": True}
+cropSpaceItem_Item = {"container": statusDesktop_mainWindow_overlay, "id": "cropSpaceItem", "type": "Item",
+                      "unnamed": 1, "visible": True}
+make_picture_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                             "objectName": "imageCropperAcceptButton", "type": "StatusButton", "visible": True}
 o_DropShadow = {"container": statusDesktop_mainWindow_overlay, "type": "DropShadow", "unnamed": 1, "visible": True}
 
 # Emoji Popup
-mainWallet_AddEditAccountPopup_AccountEmojiSearchBox = {"container": statusDesktop_mainWindow, "objectName": "StatusEmojiPopup_searchBox", "type": "TextEdit", "visible": True}
-mainWallet_AddEditAccountPopup_AccountEmoji = {"container": statusDesktop_mainWindow, "type": "StatusEmoji", "visible": True}
+mainWallet_AddEditAccountPopup_AccountEmojiSearchBox = {"container": statusDesktop_mainWindow,
+                                                        "objectName": "StatusEmojiPopup_searchBox", "type": "TextEdit",
+                                                        "visible": True}
+mainWallet_AddEditAccountPopup_AccountEmoji = {"container": statusDesktop_mainWindow, "type": "StatusEmoji",
+                                               "visible": True}
 
 # Delete Popup
-o_StatusDialogBackground = {"container": statusDesktop_mainWindow_overlay, "type": "StatusDialogBackground", "unnamed": 1, "visible": True}
-delete_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "deleteChatConfirmationDialogDeleteButton", "type": "StatusButton", "visible": True}
+o_StatusDialogBackground = {"container": statusDesktop_mainWindow_overlay, "type": "StatusDialogBackground",
+                            "unnamed": 1, "visible": True}
+delete_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                       "objectName": "deleteChatConfirmationDialogDeleteButton", "type": "StatusButton",
+                       "visible": True}
 
 # Authenticate Popup
-keycardSharedPopupContent_KeycardPopupContent = {"container": statusDesktop_mainWindow_overlay, "objectName": "KeycardSharedPopupContent", "type": "KeycardPopupContent", "visible": True}
-password_PlaceholderText = {"container": statusDesktop_mainWindow_overlay, "type": "PlaceholderText", "unnamed": 1, "visible": True}
-authenticate_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "PrimaryButton", "text": "Authenticate", "type": "StatusButton", "visible": True}
+keycardSharedPopupContent_KeycardPopupContent = {"container": statusDesktop_mainWindow_overlay,
+                                                 "objectName": "KeycardSharedPopupContent",
+                                                 "type": "KeycardPopupContent", "visible": True}
+password_PlaceholderText = {"container": statusDesktop_mainWindow_overlay, "type": "PlaceholderText", "unnamed": 1,
+                            "visible": True}
+authenticate_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "PrimaryButton",
+                             "text": "Authenticate", "type": "StatusButton", "visible": True}
 
 # Shared Popup
-sharedPopup_Popup_Content = {"container": statusDesktop_mainWindow, "objectName": "KeycardSharedPopupContent", "type": "Item"}
-sharedPopup_Password_Input = {"container": sharedPopup_Popup_Content, "objectName": "keycardPasswordInput", "type": "TextField"}
-sharedPopup_Primary_Button = {"container": statusDesktop_mainWindow, "objectName": "PrimaryButton", "type": "StatusButton", "visible": True, "enabled": True}
+sharedPopup_Popup_Content = {"container": statusDesktop_mainWindow, "objectName": "KeycardSharedPopupContent",
+                             "type": "Item"}
+sharedPopup_Password_Input = {"container": sharedPopup_Popup_Content, "objectName": "keycardPasswordInput",
+                              "type": "TextField"}
+sharedPopup_Primary_Button = {"container": statusDesktop_mainWindow, "objectName": "PrimaryButton",
+                              "type": "StatusButton", "visible": True, "enabled": True}
 
 # Wallet Account Popup
-mainWallet_AddEditAccountPopup_derivationPath = {"container": statusDesktop_mainWindow, "objectName": RegularExpression("AddAccountPopup-PreDefinedDerivationPath*"), "type": "StatusListItem", "visible": True}
-mainWallet_Address_Panel = {"container": statusDesktop_mainWindow, "objectName": "addressPanel", "type": "StatusAddressPanel", "visible": True}
-addAccountPopup_GeneratedAddress = {"container": statusDesktop_mainWindow_overlay_popup2, "type": "Rectangle", "visible": True}
-address_0x_StatusBaseText = {"container": statusDesktop_mainWindow_overlay_popup2, "text": RegularExpression("0x*"), "type": "StatusBaseText", "unnamed": 1, "visible": True}
-addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator = {"container": statusDesktop_mainWindow_overlay_popup2, "objectName": "AddAccountPopup-GeneratedAddressesListPageIndicatior", "type": "StatusPageIndicator", "visible": True}
-page_StatusBaseButton = {"checkable": False, "container": addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator, "objectName": RegularExpression("Page-*"), "type": "StatusBaseButton", "visible": True}
+mainWallet_AddEditAccountPopup_derivationPath = {"container": statusDesktop_mainWindow, "objectName": RegularExpression(
+    "AddAccountPopup-PreDefinedDerivationPath*"), "type": "StatusListItem", "visible": True}
+mainWallet_Address_Panel = {"container": statusDesktop_mainWindow, "objectName": "addressPanel",
+                            "type": "StatusAddressPanel", "visible": True}
+addAccountPopup_GeneratedAddress = {"container": statusDesktop_mainWindow_overlay_popup2, "type": "Rectangle",
+                                    "visible": True}
+address_0x_StatusBaseText = {"container": statusDesktop_mainWindow_overlay_popup2, "text": RegularExpression("0x*"),
+                             "type": "StatusBaseText", "unnamed": 1, "visible": True}
+addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator = {
+    "container": statusDesktop_mainWindow_overlay_popup2,
+    "objectName": "AddAccountPopup-GeneratedAddressesListPageIndicatior", "type": "StatusPageIndicator",
+    "visible": True}
+page_StatusBaseButton = {"checkable": False,
+                         "container": addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator,
+                         "objectName": RegularExpression("Page-*"), "type": "StatusBaseButton", "visible": True}
 
 # Add/Edit account popup:
 grid_Grid = {"container": statusDesktop_mainWindow_overlay, "id": "grid", "type": "Grid", "unnamed": 1, "visible": True}
-color_StatusColorRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "type": "StatusColorRadioButton", "unnamed": 1, "visible": True}
+color_StatusColorRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay,
+                                "type": "StatusColorRadioButton", "unnamed": 1, "visible": True}
 
-mainWallet_AddEditAccountPopup_Content = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-Content", "type": "Item", "visible": True}
-mainWallet_AddEditAccountPopup_PrimaryButton = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-PrimaryButton", "type": "StatusButton", "visible": True}
-mainWallet_AddEditAccountPopup_BackButton = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-BackButton", "type": "StatusBackButton", "visible": True}
-mainWallet_AddEditAccountPopup_AccountNameComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-AccountName", "type": "StatusInput", "visible": True}
-mainWallet_AddEditAccountPopup_AccountName = {"container": mainWallet_AddEditAccountPopup_AccountNameComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_AccountColorComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-AccountColor", "type": "StatusColorSelectorGrid", "visible": True}
-mainWallet_AddEditAccountPopup_AccountColorSelector = {"container": mainWallet_AddEditAccountPopup_AccountColorComponent, "type": "Repeater", "objectName": "statusColorRepeater", "visible": True, "enabled": True}
-mainWallet_AddEditAccountPopup_AccountEmojiPopupButton = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-AccountEmoji", "type": "StatusFlatRoundButton", "visible": True}
-mainWallet_AddEditAccountPopup_SelectedOrigin = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-SelectedOrigin", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_OriginOption_Placeholder = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-OriginOption-%NAME%", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_OriginOptionNewMasterKey = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-OriginOption-LABEL-OPTION-ADD-NEW-MASTER-KEY", "type": "StatusListItem", "visible": True}
-addAccountPopup_OriginOption_StatusListItem = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_Content = {"container": statusDesktop_mainWindow,
+                                          "objectName": "AddAccountPopup-Content", "type": "Item", "visible": True}
+mainWallet_AddEditAccountPopup_PrimaryButton = {"container": statusDesktop_mainWindow,
+                                                "objectName": "AddAccountPopup-PrimaryButton", "type": "StatusButton",
+                                                "visible": True}
+mainWallet_AddEditAccountPopup_BackButton = {"container": statusDesktop_mainWindow,
+                                             "objectName": "AddAccountPopup-BackButton", "type": "StatusBackButton",
+                                             "visible": True}
+mainWallet_AddEditAccountPopup_AccountNameComponent = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                       "objectName": "AddAccountPopup-AccountName",
+                                                       "type": "StatusInput", "visible": True}
+mainWallet_AddEditAccountPopup_AccountName = {"container": mainWallet_AddEditAccountPopup_AccountNameComponent,
+                                              "type": "TextEdit", "unnamed": 1, "visible": True}
+mainWallet_AddEditAccountPopup_AccountColorComponent = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                        "objectName": "AddAccountPopup-AccountColor",
+                                                        "type": "StatusColorSelectorGrid", "visible": True}
+mainWallet_AddEditAccountPopup_AccountColorSelector = {
+    "container": mainWallet_AddEditAccountPopup_AccountColorComponent, "type": "Repeater",
+    "objectName": "statusColorRepeater", "visible": True, "enabled": True}
+mainWallet_AddEditAccountPopup_AccountEmojiPopupButton = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                          "objectName": "AddAccountPopup-AccountEmoji",
+                                                          "type": "StatusFlatRoundButton", "visible": True}
+mainWallet_AddEditAccountPopup_SelectedOrigin = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                 "objectName": "AddAccountPopup-SelectedOrigin",
+                                                 "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_OriginOption_Placeholder = {"container": statusDesktop_mainWindow,
+                                                           "objectName": "AddAccountPopup-OriginOption-%NAME%",
+                                                           "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_OriginOptionNewMasterKey = {"container": statusDesktop_mainWindow,
+                                                           "objectName": "AddAccountPopup-OriginOption-LABEL-OPTION-ADD-NEW-MASTER-KEY",
+                                                           "type": "StatusListItem", "visible": True}
+addAccountPopup_OriginOption_StatusListItem = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListItem",
+                                               "visible": True}
 
-mainWallet_AddEditAccountPopup_OriginOptionWatchOnlyAcc = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-OriginOption-LABEL-OPTION-ADD-WATCH-ONLY-ACC", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_AccountWatchOnlyAddressComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-WatchOnlyAddress", "type": "StatusInput", "visible": True}
-mainWallet_AddEditAccountPopup_AccountWatchOnlyAddress = {"container": mainWallet_AddEditAccountPopup_AccountWatchOnlyAddressComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_EditDerivationPathButton = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-EditDerivationPath", "type": "StatusButton", "visible": True}
-mainWallet_AddEditAccountPopup_ResetDerivationPathButton = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-ResetDerivationPath", "type": "StatusLinkText", "enabled": True, "visible": True}
-mainWallet_AddEditAccountPopup_DerivationPathInputComponent = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-DerivationPathInput", "type": "DerivationPathInput", "visible": True}
-mainWallet_AddEditAccountPopup_DerivationPathInput = {"container": mainWallet_AddEditAccountPopup_DerivationPathInputComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_PreDefinedDerivationPathsButton = {"container": mainWallet_AddEditAccountPopup_DerivationPathInputComponent, "objectName": "chevron-down-icon", "type": "StatusIcon", "visible": True}
-mainWallet_AddEditAccountPopup_GeneratedAddressComponent = {"container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-GeneratedAddress", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_NonEthDerivationPathCheckBox = {"checkable": True, "container": statusDesktop_mainWindow, "objectName": "AddAccountPopup-ConfirmAddingNonEthDerivationPath", "type": "StatusCheckBox", "visible": True}
-mainWallet_AddEditAccountPopup_MasterKey_ImportPrivateKeyOption = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-ImportPrivateKey", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_PrivateKey = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-PrivateKeyInput", "type": "StatusPasswordInput", "visible": True}
-mainWallet_AddEditAccountPopup_PrivateKeyNameComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-PrivateKeyName", "type": "StatusInput", "visible": True}
-mainWallet_AddEditAccountPopup_PrivateKeyName = {"container": mainWallet_AddEditAccountPopup_PrivateKeyNameComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_MasterKey_GoToKeycardSettingsOption = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-GoToKeycardSettings", "type": "StatusButton", "visible": True}
-mainWallet_AddEditAccountPopup_MasterKey_ImportSeedPhraseOption = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-ImportUsingSeedPhrase", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_MasterKey_GenerateSeedPhraseOption = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-GenerateNewMasterKey", "type": "StatusListItem", "visible": True}
-mainWallet_AddEditAccountPopup_ImportedSeedPhraseKeyNameComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-ImportedSeedPhraseKeyName", "type": "StatusInput", "visible": True}
-mainWallet_AddEditAccountPopup_ImportedSeedPhraseKeyName = {"container": mainWallet_AddEditAccountPopup_ImportedSeedPhraseKeyNameComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_GeneratedSeedPhraseKeyNameComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-GeneratedSeedPhraseKeyName", "type": "StatusInput", "visible": True}
-mainWallet_AddEditAccountPopup_GeneratedSeedPhraseKeyName = {"container": mainWallet_AddEditAccountPopup_GeneratedSeedPhraseKeyNameComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_HavePenAndPaperCheckBox = {"checkable": True, "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-HavePenAndPaper", "type": "StatusCheckBox", "visible": True}
-mainWallet_AddEditAccountPopup_SeedPhraseWrittenCheckBox = {"checkable": True, "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-SeedPhraseWritten", "type": "StatusCheckBox", "visible": True}
-mainWallet_AddEditAccountPopup_StoringSeedPhraseConfirmedCheckBox = {"checkable": True, "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-StoringSeedPhraseConfirmed", "type": "StatusCheckBox", "visible": True}
-mainWallet_AddEditAccountPopup_SeedBackupAknowledgeCheckBox = {"checkable": True, "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-SeedBackupAknowledge", "type": "StatusCheckBox", "visible": True}
-mainWallet_AddEditAccountPopup_RevealSeedPhraseButton = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-RevealSeedPhrase", "type": "StatusButton", "visible": True}
-mainWallet_AddEditAccountPopup_SeedPhraseWordAtIndex_Placeholder = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "SeedPhraseWordAtIndex-%WORD-INDEX%", "type": "StatusSeedPhraseInput", "visible": True}
-mainWallet_AddEditAccountPopup_EnterSeedPhraseWordComponent = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-EnterSeedPhraseWord", "type": "StatusInput", "visible": True}
-mainWallet_AddEditAccountPopup_EnterSeedPhraseWord = {"container": mainWallet_AddEditAccountPopup_EnterSeedPhraseWordComponent, "type": "TextEdit", "unnamed": 1, "visible": True}
-mainWallet_AddEditAccountPopup_SPWord = {"container": mainWallet_AddEditAccountPopup_Content, "type": "TextEdit", "objectName": RegularExpression("statusSeedPhraseInputField*")}
-mainWallet_AddEditAccountPopup_12WordsButton = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "12SeedButton", "type": "StatusSwitchTabButton"}
-mainWallet_AddEditAccountPopup_18WordsButton = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "18SeedButton", "type": "StatusSwitchTabButton"}
-mainWallet_AddEditAccountPopup_24WordsButton = {"container": mainWallet_AddEditAccountPopup_Content, "objectName": "24SeedButton", "type": "StatusSwitchTabButton"}
+mainWallet_AddEditAccountPopup_OriginOptionWatchOnlyAcc = {"container": statusDesktop_mainWindow,
+                                                           "objectName": "AddAccountPopup-OriginOption-LABEL-OPTION-ADD-WATCH-ONLY-ACC",
+                                                           "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_AccountWatchOnlyAddressComponent = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                                   "objectName": "AddAccountPopup-WatchOnlyAddress",
+                                                                   "type": "StatusInput", "visible": True}
+mainWallet_AddEditAccountPopup_AccountWatchOnlyAddress = {
+    "container": mainWallet_AddEditAccountPopup_AccountWatchOnlyAddressComponent, "type": "TextEdit", "unnamed": 1,
+    "visible": True}
+mainWallet_AddEditAccountPopup_EditDerivationPathButton = {"container": statusDesktop_mainWindow,
+                                                           "objectName": "AddAccountPopup-EditDerivationPath",
+                                                           "type": "StatusButton", "visible": True}
+mainWallet_AddEditAccountPopup_ResetDerivationPathButton = {"container": statusDesktop_mainWindow,
+                                                            "objectName": "AddAccountPopup-ResetDerivationPath",
+                                                            "type": "StatusLinkText", "enabled": True, "visible": True}
+mainWallet_AddEditAccountPopup_DerivationPathInputComponent = {"container": statusDesktop_mainWindow,
+                                                               "objectName": "AddAccountPopup-DerivationPathInput",
+                                                               "type": "DerivationPathInput", "visible": True}
+mainWallet_AddEditAccountPopup_DerivationPathInput = {
+    "container": mainWallet_AddEditAccountPopup_DerivationPathInputComponent, "type": "TextEdit", "unnamed": 1,
+    "visible": True}
+mainWallet_AddEditAccountPopup_PreDefinedDerivationPathsButton = {
+    "container": mainWallet_AddEditAccountPopup_DerivationPathInputComponent, "objectName": "chevron-down-icon",
+    "type": "StatusIcon", "visible": True}
+mainWallet_AddEditAccountPopup_GeneratedAddressComponent = {"container": statusDesktop_mainWindow,
+                                                            "objectName": "AddAccountPopup-GeneratedAddress",
+                                                            "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_NonEthDerivationPathCheckBox = {"checkable": True, "container": statusDesktop_mainWindow,
+                                                               "objectName": "AddAccountPopup-ConfirmAddingNonEthDerivationPath",
+                                                               "type": "StatusCheckBox", "visible": True}
+mainWallet_AddEditAccountPopup_MasterKey_ImportPrivateKeyOption = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                                   "objectName": "AddAccountPopup-ImportPrivateKey",
+                                                                   "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_PrivateKey = {"container": mainWallet_AddEditAccountPopup_Content,
+                                             "objectName": "AddAccountPopup-PrivateKeyInput",
+                                             "type": "StatusPasswordInput", "visible": True}
+mainWallet_AddEditAccountPopup_PrivateKeyNameComponent = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                          "objectName": "AddAccountPopup-PrivateKeyName",
+                                                          "type": "StatusInput", "visible": True}
+mainWallet_AddEditAccountPopup_PrivateKeyName = {"container": mainWallet_AddEditAccountPopup_PrivateKeyNameComponent,
+                                                 "type": "TextEdit", "unnamed": 1, "visible": True}
+mainWallet_AddEditAccountPopup_MasterKey_GoToKeycardSettingsOption = {
+    "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-GoToKeycardSettings",
+    "type": "StatusButton", "visible": True}
+mainWallet_AddEditAccountPopup_MasterKey_ImportSeedPhraseOption = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                                   "objectName": "AddAccountPopup-ImportUsingSeedPhrase",
+                                                                   "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_MasterKey_GenerateSeedPhraseOption = {
+    "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-GenerateNewMasterKey",
+    "type": "StatusListItem", "visible": True}
+mainWallet_AddEditAccountPopup_ImportedSeedPhraseKeyNameComponent = {
+    "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-ImportedSeedPhraseKeyName",
+    "type": "StatusInput", "visible": True}
+mainWallet_AddEditAccountPopup_ImportedSeedPhraseKeyName = {
+    "container": mainWallet_AddEditAccountPopup_ImportedSeedPhraseKeyNameComponent, "type": "TextEdit", "unnamed": 1,
+    "visible": True}
+mainWallet_AddEditAccountPopup_GeneratedSeedPhraseKeyNameComponent = {
+    "container": mainWallet_AddEditAccountPopup_Content, "objectName": "AddAccountPopup-GeneratedSeedPhraseKeyName",
+    "type": "StatusInput", "visible": True}
+mainWallet_AddEditAccountPopup_GeneratedSeedPhraseKeyName = {
+    "container": mainWallet_AddEditAccountPopup_GeneratedSeedPhraseKeyNameComponent, "type": "TextEdit", "unnamed": 1,
+    "visible": True}
+mainWallet_AddEditAccountPopup_HavePenAndPaperCheckBox = {"checkable": True,
+                                                          "container": mainWallet_AddEditAccountPopup_Content,
+                                                          "objectName": "AddAccountPopup-HavePenAndPaper",
+                                                          "type": "StatusCheckBox", "visible": True}
+mainWallet_AddEditAccountPopup_SeedPhraseWrittenCheckBox = {"checkable": True,
+                                                            "container": mainWallet_AddEditAccountPopup_Content,
+                                                            "objectName": "AddAccountPopup-SeedPhraseWritten",
+                                                            "type": "StatusCheckBox", "visible": True}
+mainWallet_AddEditAccountPopup_StoringSeedPhraseConfirmedCheckBox = {"checkable": True,
+                                                                     "container": mainWallet_AddEditAccountPopup_Content,
+                                                                     "objectName": "AddAccountPopup-StoringSeedPhraseConfirmed",
+                                                                     "type": "StatusCheckBox", "visible": True}
+mainWallet_AddEditAccountPopup_SeedBackupAknowledgeCheckBox = {"checkable": True,
+                                                               "container": mainWallet_AddEditAccountPopup_Content,
+                                                               "objectName": "AddAccountPopup-SeedBackupAknowledge",
+                                                               "type": "StatusCheckBox", "visible": True}
+mainWallet_AddEditAccountPopup_RevealSeedPhraseButton = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                         "objectName": "AddAccountPopup-RevealSeedPhrase",
+                                                         "type": "StatusButton", "visible": True}
+mainWallet_AddEditAccountPopup_SeedPhraseWordAtIndex_Placeholder = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                                    "objectName": "SeedPhraseWordAtIndex-%WORD-INDEX%",
+                                                                    "type": "StatusSeedPhraseInput", "visible": True}
+mainWallet_AddEditAccountPopup_EnterSeedPhraseWordComponent = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                               "objectName": "AddAccountPopup-EnterSeedPhraseWord",
+                                                               "type": "StatusInput", "visible": True}
+mainWallet_AddEditAccountPopup_EnterSeedPhraseWord = {
+    "container": mainWallet_AddEditAccountPopup_EnterSeedPhraseWordComponent, "type": "TextEdit", "unnamed": 1,
+    "visible": True}
+mainWallet_AddEditAccountPopup_SPWord = {"container": mainWallet_AddEditAccountPopup_Content, "type": "TextEdit",
+                                         "objectName": RegularExpression("statusSeedPhraseInputField*")}
+mainWallet_AddEditAccountPopup_12WordsButton = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                "objectName": "12SeedButton", "type": "StatusSwitchTabButton"}
+mainWallet_AddEditAccountPopup_18WordsButton = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                "objectName": "18SeedButton", "type": "StatusSwitchTabButton"}
+mainWallet_AddEditAccountPopup_24WordsButton = {"container": mainWallet_AddEditAccountPopup_Content,
+                                                "objectName": "24SeedButton", "type": "StatusSwitchTabButton"}
 
 # Edit Account from settings popup
-editWalletSettings_renameButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "renameAccountModalSaveBtn", "type": "StatusButton"}
-editWalletSettings_AccountNameInput = {"container": statusDesktop_mainWindow_overlay, "objectName": "renameAccountNameInput", "type": "TextEdit", "visible": True}
-editWalletSettings_EmojiSelector = {"container": statusDesktop_mainWindow_overlay, "objectName": "statusSmartIdenticonLetter", "type": "StatusLetterIdenticon", "visible": True}
-editWalletSettings_ColorSelector = {"container": statusDesktop_mainWindow_overlay, "type": "StatusColorRadioButton", "unnamed": 1, "visible": True}
-editWalletSettings_EmojiItem = {"container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("statusEmoji_*"), "type": "StatusEmoji"}
+editWalletSettings_renameButton = {"container": statusDesktop_mainWindow_overlay,
+                                   "objectName": "renameAccountModalSaveBtn", "type": "StatusButton"}
+editWalletSettings_AccountNameInput = {"container": statusDesktop_mainWindow_overlay,
+                                       "objectName": "renameAccountNameInput", "type": "TextEdit", "visible": True}
+editWalletSettings_EmojiSelector = {"container": statusDesktop_mainWindow_overlay,
+                                    "objectName": "statusSmartIdenticonLetter", "type": "StatusLetterIdenticon",
+                                    "visible": True}
+editWalletSettings_ColorSelector = {"container": statusDesktop_mainWindow_overlay, "type": "StatusColorRadioButton",
+                                    "unnamed": 1, "visible": True}
+editWalletSettings_EmojiItem = {"container": statusDesktop_mainWindow_overlay,
+                                "objectName": RegularExpression("statusEmoji_*"), "type": "StatusEmoji"}
 
 # Remove Account from settings popup
-removeConfirmationCrossCloseButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "close-icon", "type": "StatusIcon", "visible": True}
-removeConfirmationTextTitle = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle", "type": "StatusBaseText", "visible": True}
-removeConfirmationTextBody = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1, "visible": True}
-removeConfirmationRemoveButton = {"container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("confirm*"), "type": "StatusButton"}
+removeConfirmationCrossCloseButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "close-icon",
+                                      "type": "StatusIcon", "visible": True}
+removeConfirmationTextTitle = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle",
+                               "type": "StatusBaseText", "visible": True}
+removeConfirmationTextBody = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1,
+                              "visible": True}
+removeConfirmationRemoveButton = {"container": statusDesktop_mainWindow_overlay,
+                                  "objectName": RegularExpression("confirm*"), "type": "StatusButton"}
 
 # Testnet mode popup
-turn_on_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn on testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}
-turn_off_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn off testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}
-testnet_mode_cancelButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
-testnet_mode_closeCrossButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerActionsCloseButton", "type": "StatusFlatRoundButton", "visible": True}
+turn_on_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn",
+                                     "text": "Turn on testnet mode", "type": "StatusButton", "unnamed": 1,
+                                     "visible": True}
+turn_off_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn",
+                                      "text": "Turn off testnet mode", "type": "StatusButton", "unnamed": 1,
+                                      "visible": True}
+testnet_mode_cancelButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1,
+                             "visible": True}
+testnet_mode_closeCrossButton = {"container": statusDesktop_mainWindow_overlay,
+                                 "objectName": "headerActionsCloseButton", "type": "StatusFlatRoundButton",
+                                 "visible": True}
 
 # Testnet mode banner
-mainWindow_testnetBanner_ModuleWarning = {"container": statusDesktop_mainWindow, "objectName": "testnetBanner", "type": "ModuleWarning", "visible": True}
-mainWindow_Turn_off_Button = {"checkable": False, "container": statusDesktop_mainWindow, "id": "button", "text": "Turn off", "type": "Button", "unnamed": 1, "visible": True}
+mainWindow_testnetBanner_ModuleWarning = {"container": statusDesktop_mainWindow, "objectName": "testnetBanner",
+                                          "type": "ModuleWarning", "visible": True}
+mainWindow_Turn_off_Button = {"checkable": False, "container": statusDesktop_mainWindow, "id": "button",
+                              "text": "Turn off", "type": "Button", "unnamed": 1, "visible": True}
 
 # Wallet toast message
-mainWallet_Ephemeral_Notification_List = {"container": statusDesktop_mainWindow, "objectName": "ephemeralNotificationList", "type": "StatusListView"}
-ephemeralNotificationList_StatusToastMessage = {"container": mainWallet_Ephemeral_Notification_List, "objectName": "statusToastMessage", "type": "StatusToastMessage"}
+mainWallet_Ephemeral_Notification_List = {"container": statusDesktop_mainWindow,
+                                          "objectName": "ephemeralNotificationList", "type": "StatusListView"}
+ephemeralNotificationList_StatusToastMessage = {"container": mainWallet_Ephemeral_Notification_List,
+                                                "objectName": "statusToastMessage", "type": "StatusToastMessage"}
 
 # Change password popup
-change_password_menu_current_password = {"container": statusDesktop_mainWindow_overlay, "objectName": "passwordViewCurrentPassword", "type": "StatusPasswordInput", "visible": True}
-change_password_menu_new_password = {"container": statusDesktop_mainWindow_overlay, "objectName": "passwordViewNewPassword", "type": "StatusPasswordInput", "visible": True}
-change_password_menu_new_password_confirm = {"container": statusDesktop_mainWindow_overlay, "objectName": "passwordViewNewPasswordConfirm", "type": "StatusPasswordInput", "visible": True}
-change_password_menu_submit_button = {"container": statusDesktop_mainWindow_overlay, "objectName": "changePasswordModalSubmitButton", "type": "StatusButton", "visible": True}
-change_password_success_menu_sign_out_quit_button = {"container": statusDesktop_mainWindow_overlay, "objectName": "changePasswordSuccessModalSignOutAndQuitButton", "type": "StatusButton", "visible": True}
+change_password_menu_current_password = {"container": statusDesktop_mainWindow_overlay,
+                                         "objectName": "passwordViewCurrentPassword", "type": "StatusPasswordInput",
+                                         "visible": True}
+change_password_menu_new_password = {"container": statusDesktop_mainWindow_overlay,
+                                     "objectName": "passwordViewNewPassword", "type": "StatusPasswordInput",
+                                     "visible": True}
+change_password_menu_new_password_confirm = {"container": statusDesktop_mainWindow_overlay,
+                                             "objectName": "passwordViewNewPasswordConfirm",
+                                             "type": "StatusPasswordInput", "visible": True}
+change_password_menu_submit_button = {"container": statusDesktop_mainWindow_overlay,
+                                      "objectName": "changePasswordModalSubmitButton", "type": "StatusButton",
+                                      "visible": True}
+change_password_success_menu_sign_out_quit_button = {"container": statusDesktop_mainWindow_overlay,
+                                                     "objectName": "changePasswordSuccessModalSignOutAndQuitButton",
+                                                     "type": "StatusButton", "visible": True}
 
 # Social Links Popup
-socialLink_StatusListItem = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListItem", "title": "", "visible": True}
-placeholder_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "id": "placeholder", "type": "StatusBaseText", "unnamed": 1, "visible": True}
-social_links_back_StatusBackButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBackButton", "unnamed": 1, "visible": True}
-social_links_add_StatusBackButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
-linksView = {"container": statusDesktop_mainWindow, "id": "linksView", "type": "StatusListView", "unnamed": 1, "visible": True}
+socialLink_StatusListItem = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListItem", "title": "",
+                             "visible": True}
+placeholder_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "id": "placeholder",
+                              "type": "StatusBaseText", "unnamed": 1, "visible": True}
+social_links_back_StatusBackButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBackButton",
+                                      "unnamed": 1, "visible": True}
+social_links_add_StatusBackButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
+                                     "unnamed": 1, "visible": True}
+linksView = {"container": statusDesktop_mainWindow, "id": "linksView", "type": "StatusListView", "unnamed": 1,
+             "visible": True}
 
 # Changes detected popup
-mainWindow_settingsDirtyToastMessage_SettingsDirtyToastMessage = {"container": ":statusDesktop_mainWindow", "id": "settingsDirtyToastMessage", "type": "SettingsDirtyToastMessage", "unnamed": 1, "visible": True}
-settingsSave_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
+mainWindow_settingsDirtyToastMessage_SettingsDirtyToastMessage = {"container": ":statusDesktop_mainWindow",
+                                                                  "id": "settingsDirtyToastMessage",
+                                                                  "type": "SettingsDirtyToastMessage", "unnamed": 1,
+                                                                  "visible": True}
+settingsSave_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton",
+                             "type": "StatusButton", "visible": True}
 
 # Back up seed phrase banner
-mainWindow_secureYourSeedPhraseBanner_ModuleWarning = {"container": statusDesktop_mainWindow, "objectName": "secureYourSeedPhraseBanner", "type": "ModuleWarning", "visible": True}
-mainWindow_secureYourSeedPhraseBanner_Button = {"container": statusDesktop_mainWindow, "id": "button", "text": "Back up now", "type": "Button", "unnamed": 1, "visible": True}
+mainWindow_secureYourSeedPhraseBanner_ModuleWarning = {"container": statusDesktop_mainWindow,
+                                                       "objectName": "secureYourSeedPhraseBanner",
+                                                       "type": "ModuleWarning", "visible": True}
+mainWindow_secureYourSeedPhraseBanner_Button = {"container": statusDesktop_mainWindow, "id": "button",
+                                                "text": "Back up now", "type": "Button", "unnamed": 1, "visible": True}
 
 # Sync new device popup
-copy_SyncCodeStatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "syncCodeCopyButton", "type": "StatusButton", "visible": True}
-done_SyncCodeStatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "syncAnewDeviceNextButton", "type": "StatusButton", "visible": True}
-syncCodeInput_StatusPasswordInput = {"container": statusDesktop_mainWindow_overlay, "id": "syncCodeInput", "type": "StatusPasswordInput", "unnamed": 1, "visible": True}
+copy_SyncCodeStatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "syncCodeCopyButton",
+                             "type": "StatusButton", "visible": True}
+done_SyncCodeStatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "syncAnewDeviceNextButton",
+                             "type": "StatusButton", "visible": True}
+syncCodeInput_StatusPasswordInput = {"container": statusDesktop_mainWindow_overlay, "id": "syncCodeInput",
+                                     "type": "StatusPasswordInput", "unnamed": 1, "visible": True}
 
 # Edit group name and image popup
-groupChatEdit_name_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "groupChatEdit_name", "type": "TextEdit", "visible": True}
-save_changes_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "groupChatEdit_save", "type": "StatusButton", "visible": True}
+groupChatEdit_name_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "groupChatEdit_name",
+                               "type": "TextEdit", "visible": True}
+save_changes_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                             "objectName": "groupChatEdit_save", "type": "StatusButton", "visible": True}
 
 # Leave group popup
-leave_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "leaveGroupConfirmationDialogLeaveButton", "type": "StatusButton", "visible": True}
+leave_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                      "objectName": "leaveGroupConfirmationDialogLeaveButton", "type": "StatusButton", "visible": True}
 
 # Create Keycard account with new seed phrase popup
-cancel_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "id": "cancelButton", "type": "StatusButton", "visible": True}
-image_KeycardImage = {"container": statusDesktop_mainWindow_overlay, "id": "image", "type": "KeycardImage", "unnamed": 1, "visible": True}
+cancel_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "id": "cancelButton",
+                       "type": "StatusButton", "visible": True}
+image_KeycardImage = {"container": statusDesktop_mainWindow_overlay, "id": "image", "type": "KeycardImage",
+                      "unnamed": 1, "visible": True}
 img_Image = {"container": statusDesktop_mainWindow_overlay, "id": "img", "type": "Image", "unnamed": 1, "visible": True}
-headerTitle = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle", "type": "StatusBaseText", "visible": True}
+headerTitle = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle", "type": "StatusBaseText",
+               "visible": True}
 o_KeycardInit = {"container": statusDesktop_mainWindow_overlay, "type": "KeycardInit", "unnamed": 1, "visible": True}
-keycard_reader_instruction_text = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "visible": True}
-pinInputField_StatusPinInput = {"container": statusDesktop_mainWindow_overlay, "id": "pinInputField", "type": "StatusPinInput", "unnamed": 1, "visible": True}
-inputText_TextInput = {"container": statusDesktop_mainWindow_overlay, "id": "inputText", "type": "TextInput", "unnamed": 1, "visible": False}
-nextStatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "PrimaryButton", "type": "StatusButton", "visible": True}
-revealSeedPhraseButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "AddAccountPopup-RevealSeedPhrase", "type": "StatusButton", "visible": True}
-seedPhraseWordAtIndex_Placeholder = {"container": statusDesktop_mainWindow_overlay, "objectName": "SeedPhraseWordAtIndex-%WORD-INDEX%", "type": "StatusSeedPhraseInput", "visible": True}
-word0_StatusInput = {"container": statusDesktop_mainWindow_overlay, "id": "word0", "type": "StatusInput", "unnamed": 1, "visible": True}
-word1_StatusInput = {"container": statusDesktop_mainWindow_overlay, "id": "word1", "type": "StatusInput", "unnamed": 1, "visible": True}
-word2_StatusInput = {"container": statusDesktop_mainWindow_overlay, "id": "word2", "type": "StatusInput", "unnamed": 1, "visible": True}
+keycard_reader_instruction_text = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText",
+                                   "visible": True}
+pinInputField_StatusPinInput = {"container": statusDesktop_mainWindow_overlay, "id": "pinInputField",
+                                "type": "StatusPinInput", "unnamed": 1, "visible": True}
+inputText_TextInput = {"container": statusDesktop_mainWindow_overlay, "id": "inputText", "type": "TextInput",
+                       "unnamed": 1, "visible": False}
+nextStatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "PrimaryButton",
+                    "type": "StatusButton", "visible": True}
+revealSeedPhraseButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
+                          "objectName": "AddAccountPopup-RevealSeedPhrase", "type": "StatusButton", "visible": True}
+seedPhraseWordAtIndex_Placeholder = {"container": statusDesktop_mainWindow_overlay,
+                                     "objectName": "SeedPhraseWordAtIndex-%WORD-INDEX%",
+                                     "type": "StatusSeedPhraseInput", "visible": True}
+word0_StatusInput = {"container": statusDesktop_mainWindow_overlay, "id": "word0", "type": "StatusInput", "unnamed": 1,
+                     "visible": True}
+word1_StatusInput = {"container": statusDesktop_mainWindow_overlay, "id": "word1", "type": "StatusInput", "unnamed": 1,
+                     "visible": True}
+word2_StatusInput = {"container": statusDesktop_mainWindow_overlay, "id": "word2", "type": "StatusInput", "unnamed": 1,
+                     "visible": True}
 o_KeyPairItem = {"container": statusDesktop_mainWindow_overlay, "type": "KeyPairItem", "unnamed": 1, "visible": True}
-o_KeyPairUnknownItem = {"container": statusDesktop_mainWindow_overlay, "type": "KeyPairUnknownItem", "unnamed": 1, "visible": True}
-o_StatusListItemTag = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListItemTag", "unnamed": 1, "visible": True}
-radioButton_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "radioButton", "type": "StatusRadioButton", "unnamed": 1, "visible": True}
-statusSeedPhraseInputField_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "statusSeedPhraseInputField", "type": "TextEdit", "visible": True}
-switchTabBar_StatusSwitchTabBar = {"container": statusDesktop_mainWindow_overlay, "id": "switchTabBar", "type": "StatusSwitchTabBar", "unnamed": 1, "visible": True}
-switchTabBar_12_words_StatusSwitchTabButton = {"checkable": True, "container": switchTabBar_StatusSwitchTabBar, "objectName": "12SeedButton", "text": "12 words", "type": "StatusSwitchTabButton", "visible": True}
-switchTabBar_18_words_StatusSwitchTabButton = {"checkable": True, "container": switchTabBar_StatusSwitchTabBar, "objectName": "18SeedButton", "text": "18 words", "type": "StatusSwitchTabButton", "visible": True}
-switchTabBar_24_words_StatusSwitchTabButton = {"checkable": True, "container": switchTabBar_StatusSwitchTabBar, "objectName": "24SeedButton", "text": "24 words", "type": "StatusSwitchTabButton", "visible": True}
+o_KeyPairUnknownItem = {"container": statusDesktop_mainWindow_overlay, "type": "KeyPairUnknownItem", "unnamed": 1,
+                        "visible": True}
+o_StatusListItemTag = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListItemTag", "unnamed": 1,
+                       "visible": True}
+radioButton_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "id": "radioButton",
+                                 "type": "StatusRadioButton", "unnamed": 1, "visible": True}
+statusSeedPhraseInputField_TextEdit = {"container": statusDesktop_mainWindow_overlay,
+                                       "objectName": "statusSeedPhraseInputField", "type": "TextEdit", "visible": True}
+switchTabBar_StatusSwitchTabBar = {"container": statusDesktop_mainWindow_overlay, "id": "switchTabBar",
+                                   "type": "StatusSwitchTabBar", "unnamed": 1, "visible": True}
+switchTabBar_12_words_StatusSwitchTabButton = {"checkable": True, "container": switchTabBar_StatusSwitchTabBar,
+                                               "objectName": "12SeedButton", "text": "12 words",
+                                               "type": "StatusSwitchTabButton", "visible": True}
+switchTabBar_18_words_StatusSwitchTabButton = {"checkable": True, "container": switchTabBar_StatusSwitchTabBar,
+                                               "objectName": "18SeedButton", "text": "18 words",
+                                               "type": "StatusSwitchTabButton", "visible": True}
+switchTabBar_24_words_StatusSwitchTabButton = {"checkable": True, "container": switchTabBar_StatusSwitchTabBar,
+                                               "objectName": "24SeedButton", "text": "24 words",
+                                               "type": "StatusSwitchTabButton", "visible": True}

--- a/gui/objects_map/main_names.py
+++ b/gui/objects_map/main_names.py
@@ -3,7 +3,8 @@ mainWindow_StatusWindow = {"name": "mainWindow", "type": "StatusWindow", "visibl
 statusDesktop_mainWindow_overlay = {"container": statusDesktop_mainWindow, "type": "Overlay", "unnamed": 1, "visible": True}
 statusDesktop_mainWindow_overlay_popup2 = {"container": statusDesktop_mainWindow_overlay, "occurrence": 2, "type": "PopupItem", "unnamed": 1, "visible": True}
 scrollView_StatusScrollView = {"container": statusDesktop_mainWindow_overlay, "id": "scrollView", "type": "StatusScrollView", "unnamed": 1, "visible": True}
-splashScreen = {"container": statusDesktop_mainWindow, "objectName": "splashScreen", "type": "DidYouKnowSplashScreen"}
+splashScreenMainLoader = {"container": statusDesktop_mainWindow, "objectName": "loadingAnimationLoader", "type": "Loader"}
+splashScreenDidYouKnow = {"container": statusDesktop_mainWindow, "objectName": "splashScreen", "type": "DidYouKnowSplashScreen"}
 settingsSave_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
 
 # Main right panel

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -12,7 +12,6 @@ from constants import ColorCodes
 from driver.objects_access import walk_children
 from gui.components.os.open_file_dialogs import OpenFileDialog
 from gui.components.picture_edit_popup import PictureEditPopup
-from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
 from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.elements.button import Button
 from gui.elements.object import QObject

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -12,7 +12,8 @@ from constants import ColorCodes
 from driver.objects_access import walk_children
 from gui.components.os.open_file_dialogs import OpenFileDialog
 from gui.components.picture_edit_popup import PictureEditPopup
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.text_edit import TextEdit
@@ -187,7 +188,7 @@ class SyncResultView(OnboardingView):
     def sign_in(self, attempts: int = 2):
         self._sign_in_button.click()
         try:
-            return SplashScreen().wait_until_appears()
+            return SplashScreenMainLoader().wait_until_appears()
         except:
             assert attempts > 0, f'Next button was not clicked'
             self.sign_in(attempts - 1)
@@ -479,6 +480,9 @@ class ConfirmPasswordView(OnboardingView):
     def confirm_password(self, value: str):
         self.set_password(value)
         self._confirm_button.click()
+        if configs.system.IS_MAC:
+            BiometricsView().wait_until_appears().prefer_password()
+        return SplashScreenMainLoader().wait_until_appears()
 
     @allure.step('Go back')
     def back(self):

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -40,9 +40,15 @@ class LeftPanel(QObject):
         return CommunitiesSettingsView()
 
     @allure.step('Open wallet settings')
-    def open_wallet_settings(self):
+    def open_wallet_settings(self, attempts: int = 2) -> WalletSettingsView:
         self._open_settings('4-AppMenuItem')
-        return WalletSettingsView().wait_until_appears()
+        try:
+            return WalletSettingsView().wait_until_appears()
+        except AssertionError:
+            if attempts:
+                return self.open_wallet_settings(attempts - 1)
+            else:
+                raise f"Wallet settings option was not opened"
 
     @allure.step('Open profile settings')
     def open_profile_settings(self):

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -8,7 +8,6 @@ import configs.timeouts
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
 from gui.components.picture_edit_popup import shift_image
-from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
 from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, BiometricsView, KeysView
 
@@ -73,7 +72,8 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
         if configs.system.IS_MAC:
             assert BiometricsView().is_touch_id_button_visible(), f"TouchID button is not found"
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears()
+        #SplashScreenMainLoader().wait_until_appears()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -8,7 +8,8 @@ import configs.timeouts
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
 from gui.components.picture_edit_popup import shift_image
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, BiometricsView, KeysView
 
 _logger = logging.getLogger(__name__)
@@ -72,7 +73,7 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
         if configs.system.IS_MAC:
             assert BiometricsView().is_touch_id_button_visible(), f"TouchID button is not found"
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreen().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -9,7 +9,6 @@ import constants
 from driver.aut import AUT
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
 from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.screens.onboarding import BiometricsView, AllowNotificationsView, WelcomeToStatusView, KeysView
 
@@ -44,8 +43,9 @@ def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, au
         confirm_password_view = create_password_view.create_password(user_account.password)
         confirm_password_view.confirm_password(user_account.password)
         SplashScreenMainLoader().wait_until_appears()
-        SplashScreenMainLoader().wait_until_hidden()
+        #SplashScreenMainLoader().wait_until_hidden()
         if not configs.DEV_BUILD:
+            #BetaConsentPopup().wait_until_appears()
             BetaConsentPopup().confirm()
 
     with (step('Verify that restored account reveals correct status wallet address')):

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -1,3 +1,5 @@
+import time
+
 import allure
 import pytest
 from allure_commons._allure import step
@@ -7,7 +9,8 @@ import constants
 from driver.aut import AUT
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_did_u_know import SplashScreenDidYouKnow
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.screens.onboarding import BiometricsView, AllowNotificationsView, WelcomeToStatusView, KeysView
 
 
@@ -40,9 +43,8 @@ def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, au
         create_password_view = details_view.next()
         confirm_password_view = create_password_view.create_password(user_account.password)
         confirm_password_view.confirm_password(user_account.password)
-        if configs.system.IS_MAC:
-            BiometricsView().wait_until_appears().prefer_password()
-        SplashScreen().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears()
+        SplashScreenMainLoader().wait_until_hidden()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -44,7 +44,8 @@ def test_login_with_wrong_password(aut: AUT, keys_screen, main_window, error: st
         confirm_password_view.confirm_password(user_one.password)
         if configs.system.IS_MAC:
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears()
+        #SplashScreenMainLoader().wait_until_hidden()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -11,7 +11,7 @@ from constants.onboarding import OnboardingMessages
 from driver.aut import AUT
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, KeysView, BiometricsView, LoginView
 
 
@@ -44,7 +44,7 @@ def test_login_with_wrong_password(aut: AUT, keys_screen, main_window, error: st
         confirm_password_view.confirm_password(user_one.password)
         if configs.system.IS_MAC:
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreen().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -74,7 +74,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
 
         with step('Sign in to synced account'):
             sync_result.sign_in()
-            SplashScreenMainLoader().wait_until_hidden()
+            #SplashScreenMainLoader().wait_until_hidden()
             if not configs.DEV_BUILD:
                 if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
                     BetaConsentPopup().confirm()

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -10,7 +10,7 @@ from constants import UserAccount
 from constants.syncing import SyncingSettings
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.main_window import MainWindow
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, SyncResultView, \
     SyncCodeView, SyncDeviceFoundView
@@ -74,7 +74,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
 
         with step('Sign in to synced account'):
             sync_result.sign_in()
-            SplashScreen().wait_until_hidden()
+            SplashScreenMainLoader().wait_until_hidden()
             if not configs.DEV_BUILD:
                 if driver.waitFor(lambda: BetaConsentPopup().exists, configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
                     BetaConsentPopup().confirm()

--- a/tests/onboarding/test_password_strength.py
+++ b/tests/onboarding/test_password_strength.py
@@ -8,7 +8,7 @@ from constants.onboarding import very_weak_lower_elements, very_weak_upper_eleme
     very_weak_numbers_elements, very_weak_symbols_elements, weak_elements, so_so_elements, good_elements, great_elements
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.splash_screen import SplashScreen
+from gui.components.splash_screen_main_loader import SplashScreenMainLoader
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, KeysView, BiometricsView
 
 
@@ -56,7 +56,7 @@ def test_check_password_strength_and_login(keys_screen, main_window, user_accoun
         confirm_password_view.confirm_password(password)
         if configs.system.IS_MAC:
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreen().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/onboarding/test_password_strength.py
+++ b/tests/onboarding/test_password_strength.py
@@ -56,7 +56,8 @@ def test_check_password_strength_and_login(keys_screen, main_window, user_accoun
         confirm_password_view.confirm_password(password)
         if configs.system.IS_MAC:
             BiometricsView().wait_until_appears().prefer_password()
-        SplashScreenMainLoader().wait_until_appears().wait_until_hidden()
+        SplashScreenMainLoader().wait_until_appears()
+        #SplashScreenMainLoader().wait_until_hidden()
         if not configs.DEV_BUILD:
             BetaConsentPopup().confirm()
 

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -6,8 +6,6 @@ import constants
 from driver.aut import AUT
 from gui.main_window import MainWindow
 
-pytestmark = allure.suite("Settings")
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703007',
                  'Change own display name from online identifier')

--- a/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -49,7 +49,7 @@ def test_settings_include_in_total_balance(main_screen: MainWindow, name, watche
     with step('Verify details view for the watched address'):
         assert driver.waitFor(
             lambda: acc_view.get_account_balance_value() != '0,00', configs.timeouts.UI_LOAD_TIMEOUT_MSEC), \
-                f"Watched address {watched_address} should have positive balance in account view"
+            f"Watched address {watched_address} should have positive balance in account view"
 
         assert acc_view.get_account_name_value() == name, \
             f"Watched address name is incorrect, current name is {acc_view.get_account_name_value()}, expected {name}"
@@ -74,17 +74,18 @@ def test_settings_include_in_total_balance(main_screen: MainWindow, name, watche
 
     with step('Open wallet main screen and make sure total balance is not 0 anymore'):
         main_screen.left_panel.open_wallet()
-        total_balance_after = float(wallet_main_screen.left_panel.get_total_balance_value().replace("\xa0", "")
-                                    .replace(",", ""))
-        assert total_balance_after > 0, \
-            f"Balance after adding watched address can't less than 0, when current balance is {total_balance_after}"
+
+        assert driver.waitFor(
+            lambda: float(wallet_main_screen.left_panel.get_total_balance_value().replace("\xa0", "")
+                          .replace(",", "")) > 0, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), \
+            f"Balance after adding watched address can't be 0"
 
     with step('Right click the watched address and select Exclude from total balance option'):
         main_screen.left_panel.open_wallet().left_panel.hide_include_in_total_balance_from_context_menu(name)
 
     with step('Check the balance is back to 0 again'):
         main_screen.left_panel.open_wallet()
-        total_balance_excluded = float(wallet_main_screen.left_panel.get_total_balance_value().replace("\xa0", "")
-                                       .replace(",", ""))
-        assert total_balance_excluded == 0.0, \
-            f"Balance after adding watched address should be back to 0, when current balance is {total_balance_after}"
+        assert driver.waitFor(
+            lambda: float(wallet_main_screen.left_panel.get_total_balance_value().replace("\xa0", "")
+                          .replace(",", "")) == 0, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), \
+            f"Balance after removing watched address should be back to 0"


### PR DESCRIPTION
Apparently, we have 2 splash screens:

1. splash screen with status spinning icon
2. splash screen with loading animation of words under Did you know section

They are being displayed one by one, so i decided it would be helpful to clarify which screen we are waiting for. It is a cosmetic change, no extra functionality added.