### PR TITLE
chore: add env variable

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -71,6 +71,8 @@ pipeline {
 
     TESTRAIL_URL = 'https://ethstatus.testrail.net'
     TESTRAIL_PROJECT_ID = 17
+
+    STATUS_RUNTIME_TEST_MODE = '1'
   }
 
   stages {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12736

I forgot to add `STATUS_RUNTIME_TEST_MODE = '1'` for new tests