### PR TITLE
chore: make the verification of banner conditional in back up seed phrase test

### DIFF
--- a/tests/settings/test_settings_back_up_seed.py
+++ b/tests/settings/test_settings_back_up_seed.py
@@ -2,6 +2,7 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+import configs
 import driver
 from gui.components.back_up_your_seed_phrase_banner import BackUpSeedPhraseBanner
 from gui.main_window import MainWindow
@@ -10,11 +11,12 @@ from gui.main_window import MainWindow
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703001', 'Backup seed phrase')
 @pytest.mark.case(703001)
 def test_back_up_seed_phrase(main_screen: MainWindow):
-    with step('Check back up seed phrase banner is visible for new account'):
+    with step('Check back up seed phrase option is visible for new account'):
         settings = main_screen.left_panel.open_settings()
         assert settings.left_panel.check_back_up_seed_option_present(), f"Back up seed option is not present"
-        assert BackUpSeedPhraseBanner().does_back_up_seed_banner_exist(), "Back up seed banner is not present"
-        assert BackUpSeedPhraseBanner().is_back_up_now_button_present(), 'Back up now button is not present'
+        if not configs.system.TEST_MODE:
+            assert BackUpSeedPhraseBanner().does_back_up_seed_banner_exist(), "Back up seed banner is not present"
+            assert BackUpSeedPhraseBanner().is_back_up_now_button_present(), 'Back up now button is not present'
 
     with step('Open back up seed phrase in settings'):
         back_up = settings.left_panel.open_back_up_seed_phrase()
@@ -22,5 +24,6 @@ def test_back_up_seed_phrase(main_screen: MainWindow):
 
     with step('Verify back up seed phrase banner disappeared'):
         assert not settings.left_panel.check_back_up_seed_option_present(), f"Back up seed option is present"
-        BackUpSeedPhraseBanner().wait_to_hide_the_banner()
-        assert not BackUpSeedPhraseBanner().does_back_up_seed_banner_exist(), "Back up seed banner is present"
+        if not configs.system.TEST_MODE:
+            BackUpSeedPhraseBanner().wait_to_hide_the_banner()
+            assert not BackUpSeedPhraseBanner().does_back_up_seed_banner_exist(), "Back up seed banner is present"


### PR DESCRIPTION
We don't have banners when running the app in test mode. I added condition to check the test mode and verify banner when not in test mode, otherwise skip