### PR TITLE
chore: disable tests that are timing out or failed

### DIFF
--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -14,10 +14,9 @@ from gui.screens.community import CommunityScreen
 from scripts.tools import image
 
 
-
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703084', 'Create community')
 @pytest.mark.case(703084)
-# @pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/283")
 @pytest.mark.parametrize('params', [constants.community_params])
 def test_create_community(user_account, main_screen: MainWindow, params):
     with step('Create community'):
@@ -28,15 +27,15 @@ def test_create_community(user_account, main_screen: MainWindow, params):
     with step('Verify community parameters in community overview'):
         # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
         # with step('Icon is correct'):
-            # community_icon = main_screen.left_panel.get_community_logo(params['name'])
-            # image.compare(community_icon, 'button_logo.png', timout_sec=5)
+        # community_icon = main_screen.left_panel.get_community_logo(params['name'])
+        # image.compare(community_icon, 'button_logo.png', timout_sec=5)
         with step('Name is correct'):
             assert community_screen.left_panel.name == params['name']
         with step('Members count is correct'):
             assert '1' in community_screen.left_panel.members
         # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
         # with step('Logo is correct'):
-            # image.compare(community_screen.left_panel.logo, 'logo.png')
+        # image.compare(community_screen.left_panel.logo, 'logo.png')
 
     with step('Verify community parameters in community settings view'):
         community_setting = community_screen.left_panel.open_community_settings()
@@ -70,7 +69,7 @@ def test_create_community(user_account, main_screen: MainWindow, params):
     },
 
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/283")
 def test_edit_community_separately(main_screen, community_params):
     main_screen.create_community(constants.community_params)
 
@@ -111,7 +110,7 @@ def test_edit_community_separately(main_screen, community_params):
         'outro': 'Updated Outro'
     }
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/283")
 def test_edit_community(main_screen: MainWindow, params):
     main_screen.create_community(constants.community_params)
 
@@ -133,12 +132,12 @@ def test_edit_community(main_screen: MainWindow, params):
         # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
         # with step('Icon is correct'):
         #     community_icon = main_screen.left_panel.get_community_logo(params['name'])
-            # image.compare(community_icon, 'button_updated_logo.png')
+        # image.compare(community_icon, 'button_updated_logo.png')
         with step('Name is correct'):
             assert community_screen.left_panel.name == params['name']
         # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
         # with step('Logo is correct'):
-            # image.compare(community_screen.left_panel.logo, 'updated_logo.png')
+        # image.compare(community_screen.left_panel.logo, 'updated_logo.png')
 
     with step('Verify community parameters in community settings screen'):
         settings_screen = main_screen.left_panel.open_settings()
@@ -153,7 +152,7 @@ def test_edit_community(main_screen: MainWindow, params):
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703049', 'Create community channel')
 @pytest.mark.case(703049)
 @pytest.mark.parametrize('channel_name, channel_description, channel_emoji', [('Channel', 'Description', 'sunglasses')])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/283")
 def test_create_community_channel(main_screen: MainWindow, channel_name, channel_description, channel_emoji):
     main_screen.create_community(constants.community_params)
     community_screen = main_screen.left_panel.select_community(constants.community_params['name'])
@@ -172,7 +171,7 @@ def test_create_community_channel(main_screen: MainWindow, channel_name, channel
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703050', 'Edit community channel')
 @pytest.mark.case(703050)
 @pytest.mark.parametrize('channel_name, channel_description, channel_emoji', [('Channel', 'Description', 'sunglasses')])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/283")
 def test_edit_community_channel(main_screen, channel_name, channel_description, channel_emoji):
     main_screen.create_community(constants.community_params)
     community_screen = CommunityScreen()
@@ -216,7 +215,7 @@ def test_delete_community_channel(main_screen):
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/283")
 def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -32,6 +32,7 @@ def keys_screen(main_window) -> KeysView:
     pytest.param(False),
     pytest.param(True)
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, autocomplete: bool):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -30,6 +30,7 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.case(702991)
 @pytest.mark.parametrize('error', [OnboardingMessages.PASSWORD_INCORRECT.value
                                    ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/324")
 def test_login_with_wrong_password(aut: AUT, keys_screen, main_window, error: str):
     user_one: UserAccount = constants.user_account_one
     user_one_wrong_password: UserAccount = constants.user_account_one_changed_password
@@ -71,6 +72,7 @@ def test_login_with_wrong_password(aut: AUT, keys_screen, main_window, error: st
     pytest.param('Gra', OnboardingMessages.WRONG_LOGIN_LESS_LETTERS.value),
     pytest.param('tester3@', OnboardingMessages.WRONG_LOGIN_SYMBOLS_NOT_ALLOWED.value)
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_sign_up_with_wrong_name(keys_screen, user_name: str, error: str):
     with step(f'Input name {user_name}'):
         profile_view = keys_screen.generate_new_keys()
@@ -88,6 +90,7 @@ def test_sign_up_with_wrong_name(keys_screen, user_name: str, error: str):
 @pytest.mark.parametrize('password, error', [
     pytest.param('badP', OnboardingMessages.WRONG_PASSWORD.value),
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_sign_up_with_wrong_password_in_both_fields(keys_screen, user_account, password: str, error: str):
     with step('Input correct user name'):
         profile_view = keys_screen.generate_new_keys()
@@ -111,6 +114,7 @@ def test_sign_up_with_wrong_password_in_both_fields(keys_screen, user_account, p
 @pytest.mark.parametrize('first_password, confirmation_password', [
     pytest.param('TesTEr16843/!@01', 'bad2!s'),
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_sign_up_with_wrong_password_in_confirmation_field(keys_screen, user_account, first_password: str,
                                                            confirmation_password: str):
     with step('Input correct user name'):
@@ -134,6 +138,7 @@ def test_sign_up_with_wrong_password_in_confirmation_field(keys_screen, user_acc
 @pytest.mark.parametrize('password, confirmation_again_password, error', [
     pytest.param('TesTEr16843/!@01', 'TesTEr16843/!@)', OnboardingMessages.PASSWORDS_DONT_MATCH.value),
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_sign_up_with_wrong_password_in_confirmation_again_field(keys_screen, user_account, password: str,
                                                                  confirmation_again_password: str, error: str):
     with step('Input correct user name'):
@@ -159,6 +164,7 @@ def test_sign_up_with_wrong_password_in_confirmation_again_field(keys_screen, us
 @pytest.mark.parametrize('seed_phrase', [
     pytest.param('pelican chief sudden oval media rare swamp elephant lawsuit wheal knife initial'),
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_sign_up_with_wrong_seed_phrase(keys_screen, seed_phrase: str):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -31,6 +31,7 @@ def sync_screen(main_window) -> SyncCodeView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703592', 'Sync device during onboarding')
 @pytest.mark.case(703592)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'user_account_one'])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_sync_device_during_onboarding(multiple_instance, user_data):
     user: UserAccount = constants.user_account_one
     main_window = MainWindow()
@@ -96,6 +97,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
 @pytest.mark.parametrize('wrong_sync_code', [
     pytest.param('9rhfjgfkgfj890tjfgtjfgshjef900')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_wrong_sync_code(sync_screen, wrong_sync_code):
     with step('Open sync code form'):
         sync_view = sync_screen.open_enter_sync_code_form()

--- a/tests/onboarding/test_password_strength.py
+++ b/tests/onboarding/test_password_strength.py
@@ -38,6 +38,7 @@ def keys_screen(main_window) -> KeysView:
     pytest.param('+1_3!48aT1', good_elements),
     pytest.param('+1_3!48aTq', great_elements)
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/324")
 def test_check_password_strength_and_login(keys_screen, main_window, user_account, password: str, password_strength_elements):
     with step('Input correct user name'):
         profile_view = keys_screen.generate_new_keys()

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -14,6 +14,7 @@ pytestmark = allure.suite("Settings")
 @pytest.mark.case(703007)
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 @pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
     with step('Open own profile popup and check name of user is correct'):
         profile = main_screen.left_panel.open_user_canvas()

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -13,6 +13,7 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings and change password'):
         main_screen.left_panel.open_settings().left_panel.open_profile_settings().open_change_password_popup().change_password(

--- a/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -14,6 +14,7 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_account, user_account_changed',
                          [pytest.param(constants.user.user_account_one, constants.user.user_account_one_changed_name)])
 @pytest.mark.parametrize('bio, links', [pytest.param('This is my bio', constants.social_links)])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_account, user_account_changed, bio, links):
     with step('Open profile settings and check name, bio and links'):
         profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()

--- a/tests/settings/settings_wallet/test_wallet_settings_account_order.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_account_order.py
@@ -91,6 +91,7 @@ def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_acc
     pytest.param('Status account', 'This account looks a little lonely. Add another account'
                                    ' to enable re-ordering.')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_change_account_order_not_possible(main_screen: MainWindow, default_name: str, text_on_top: str):
     with step('Open edit account order view'):
         account_order = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_account_order()

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -26,6 +26,7 @@ from gui.screens.settings_wallet import WalletSettingsView
                                                                  string.digits, k=15)), '#2a4af5', 'sunglasses',
                                           '1f60e')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12777")
 def test_delete_generated_account_from_wallet_settings(
         main_screen: MainWindow, user_account, account_name: str, color: str, emoji: str, emoji_unicode: str):
     with step('Open add account pop up from wallet settings'):

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
@@ -17,6 +17,7 @@ from gui.screens.settings import SettingsScreen
     pytest.param(''.join(random.choices(string.ascii_letters +
                                         string.digits, k=40)))
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_settings_edit_status_account(main_screen: MainWindow, new_name):
     with step('Open profile and wallet setting and check that display name equals to Status keypair name'):
         status_keypair_title = \

--- a/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -22,6 +22,7 @@ from gui.main_window import MainWindow
                              pytest.param(''.join(random.choices(string.ascii_letters +
                                                                  string.digits, k=15)), '#2a4af5', 'sunglasses', '1f60e')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12777")
 def test_add_new_account_from_wallet_settings(
         main_screen: MainWindow, user_account, account_name: str, color: str, emoji: str, emoji_unicode: str):
     with step('Open add account pop up from wallet settings'):

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
@@ -16,6 +16,7 @@ from gui.main_window import MainWindow
     pytest.param(WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value),
     pytest.param(WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value)
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_settings_networks_edit_restore_defaults(main_screen: MainWindow, network_tab: str):
 
     networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
@@ -11,6 +11,7 @@ from gui.main_window import MainWindow
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703505', 'Network: Testnet switching')
 @pytest.mark.case(703505)
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_switch_testnet_mode(main_screen: MainWindow):
     with step('Verify that Testnet toggle has subtitle'):
         networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
@@ -63,6 +64,7 @@ def test_switch_testnet_mode(main_screen: MainWindow):
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703621',
                  'Network: Enable testnet toggle and click cross button in confirmation')
 @pytest.mark.case(703621)
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_toggle_testnet_toggle_on_and_close_the_confirmation(main_screen: MainWindow):
     networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
 
@@ -91,6 +93,7 @@ def test_toggle_testnet_toggle_on_and_close_the_confirmation(main_screen: MainWi
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703622',
                  'Network:  Network: Enable Testnets, toggle testnet toggle OFF, click cancel in confirmation')
 @pytest.mark.case(703621)
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_switch_testnet_off_by_toggle_and_cancel_in_confirmation(main_screen: MainWindow):
     networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
 

--- a/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -20,6 +20,7 @@ from gui.screens.settings_wallet import WalletSettingsView
     pytest.param('0x7f1502605A2f2Cc01f9f4E7dd55e549954A8cD0C', ''.join(random.choices(string.ascii_letters +
                                                                                       string.digits, k=20)))
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_settings_include_in_total_balance(main_screen: MainWindow, name, watched_address):
     with (step('Open wallet on main screen and check the total balance for new account is 0')):
         wallet_main_screen = main_screen.left_panel.open_wallet()

--- a/tests/settings/test_settings_back_up_seed.py
+++ b/tests/settings/test_settings_back_up_seed.py
@@ -10,6 +10,7 @@ from gui.main_window import MainWindow
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703001', 'Backup seed phrase')
 @pytest.mark.case(703001)
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_back_up_seed_phrase(main_screen: MainWindow):
     with step('Check back up seed phrase option is visible for new account'):
         settings = main_screen.left_panel.open_settings()

--- a/tests/wallet_main_screen/test_wallet_main_can_add_account_after_restart.py
+++ b/tests/wallet_main_screen/test_wallet_main_can_add_account_after_restart.py
@@ -25,6 +25,7 @@ from gui.main_window import MainWindow
                          [
                              pytest.param('GenAcc2', '#2a4af5', 'sunglasses', '1f60e')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_add_generated_account_restart_add_again(
         aut: AUT, main_screen: MainWindow, user_account,
         color: str, emoji: str, emoji_unicode: str, name: str,

--- a/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
+++ b/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
@@ -18,6 +18,7 @@ from gui.screens.settings_keycard import KeycardSettingsView
 @pytest.mark.parametrize('name, new_name, new_color, new_emoji, new_emoji_unicode', [
     pytest.param('Status account', 'MyPrimaryAccount', '#216266', 'sunglasses', '1f60e')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_edit_default_wallet_account(main_screen: MainWindow, name: str, new_name: str, new_color: str, new_emoji: str,
                                      new_emoji_unicode: str):
     with step('Select wallet account'):
@@ -51,6 +52,7 @@ def test_edit_default_wallet_account(main_screen: MainWindow, name: str, new_nam
                              pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                                           'sunglasses', '1f60e', 'AccWatch1edited', '#216266', 'thumbsup', '1f44d')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_manage_watch_only_account_context_menu(main_screen: MainWindow, address: str, color: str, emoji: str,
                                                 emoji_unicode: str,
                                                 name: str, new_name: str, new_color: str, new_emoji: str,
@@ -89,6 +91,7 @@ def test_manage_watch_only_account_context_menu(main_screen: MainWindow, address
                              pytest.param('GenAcc1', '#2a4af5', 'sunglasses', '1f60e',
                                           'GenAcc1edited', '#216266', 'thumbsup', '1f44d')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_manage_generated_account(main_screen: MainWindow, user_account,
                                   color: str, emoji: str, emoji_unicode: str,
                                   name: str, new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str):
@@ -197,6 +200,7 @@ def test_manage_custom_generated_account(main_screen: MainWindow, user_account,
                              pytest.param('PrivKeyAcc1', '#2a4af5', 'sunglasses', '1f60e',
                                           'PrivKeyAcc1edited', '#216266', 'thumbsup', '1f44d')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_private_key_imported_account(main_screen: MainWindow, user_account, address_pair,
                                       name: str, color: str, emoji: str, emoji_unicode: str,
                                       new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str):
@@ -273,6 +277,7 @@ def test_private_key_imported_account(main_screen: MainWindow, user_account, add
                                           'SPAcc12edited', '#216266', 'thumbsup', '1f44d',
                                           'pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial')
                          ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_seed_phrase_imported_account(main_screen: MainWindow, user_account,
                                       name: str, color: str, emoji: str, emoji_unicode: str,
                                       new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str,
@@ -333,6 +338,7 @@ def test_seed_phrase_imported_account(main_screen: MainWindow, user_account,
                          'new_name, new_color, new_emoji, new_emoji_unicode, keypair_name', [
                              pytest.param('SPAcc', '#2a4af5', 'sunglasses', '1f60e',
                                           'SPAccedited', '#216266', 'thumbsup', '1f44d', 'SPKeyPair')])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_seed_phrase_generated_account(main_screen: MainWindow, user_account,
                                        name: str, color: str, emoji: str, emoji_unicode: str,
                                        new_name: str, new_color: str, new_emoji: str, new_emoji_unicode: str,
@@ -387,6 +393,7 @@ def test_seed_phrase_generated_account(main_screen: MainWindow, user_account,
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703514',
                  'Choosing Use Keycard when adding account')
 @pytest.mark.case(703514)
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_use_keycard_when_adding_account(main_screen: MainWindow):
     with step('Choose continue in keycard settings'):
         wallet = main_screen.left_panel.open_wallet()

--- a/tests/wallet_main_screen/test_wallet_main_saved_addresses.py
+++ b/tests/wallet_main_screen/test_wallet_main_saved_addresses.py
@@ -14,6 +14,7 @@ from gui.main_window import MainWindow
     pytest.param('Saved address name before', '0x8397bc3c5a60a1883174f722403d63a8833312b7', 'Saved address name after'),
     pytest.param('Ens name before', 'nastya.stateofus.eth', 'Ens name after')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, new_name: str):
     with step('Add new address'):
         wallet = main_screen.left_panel.open_wallet()

--- a/tests/wallet_main_screen/test_wlt_main_add_acc_manage_watched_address.py
+++ b/tests/wallet_main_screen/test_wlt_main_add_acc_manage_watched_address.py
@@ -18,6 +18,7 @@ from gui.main_window import MainWindow
     pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                  'sunglasses', '1f60e')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/322")
 def test_wallet_add_acc_add_watched_address(
         main_screen: MainWindow, address: str, color: str, emoji: str, emoji_unicode: str,
         name: str):


### PR DESCRIPTION
I am working on finding a root cause of https://github.com/status-im/desktop-qa-automation/issues/322. in order to achieve that, will disable all tests (so they not time out all the time) and i will gradually enable test by test for the time being

https://github.com/status-im/desktop-qa-automation/issues/322 
https://github.com/status-im/desktop-qa-automation/issues/323 
https://github.com/status-im/desktop-qa-automation/issues/324