### PR TITLE
chore: generate timestamp for nightly run

### DIFF
--- a/configs/testrail.py
+++ b/configs/testrail.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 CI_BUILD_URL = os.getenv('BUILD_URL', '')
 
@@ -7,3 +8,7 @@ PROJECT_ID = os.getenv('TESTRAIL_PROJECT_ID', '')
 URL = os.getenv('TESTRAIL_URL', '')
 USR = os.getenv('TESTRAIL_USR', '')
 PSW = os.getenv('TESTRAIL_PSW', '')
+
+# Because of an issue with generating a timestamp on the CI side and adding it as a parameter on the test job:
+if RUN_NAME.strip() == 'Nightly regression':
+    RUN_NAME += f' {datetime.now():%Y.%m.%d}'


### PR DESCRIPTION
#320
https://github.com/status-im/status-desktop/pull/320
Generating a name with a timestamp for TestRail Run is not working.
In PR, I added a template for the run. The timestamp will be added on the test scripts side.

Test run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1064/parameters/
Test results: https://ethstatus.testrail.net/index.php?/runs/view/13721&group_by=cases:title&group_order=asc