### PR TITLE
test: test_messaging_settings accepting and rejecting request added

### DIFF
--- a/constants/group_chat.py
+++ b/constants/group_chat.py
@@ -1,5 +1,0 @@
-from enum import Enum
-
-
-class GroupChatMessages(Enum):
-    WELCOME_GROUP_MESSAGE = "Welcome to the beginning of the "

--- a/constants/messaging.py
+++ b/constants/messaging.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Messaging(Enum):
+    WELCOME_GROUP_MESSAGE = "Welcome to the beginning of the "
+    CONTACT_REQUEST_SENT = 'Contact Request Sent'
+    NO_FRIENDS_ITEM = 'You don’t have any contacts yet'
+    NEW_CONTACT_REQUEST = 'New Contact Request'

--- a/gui/components/toast_message.py
+++ b/gui/components/toast_message.py
@@ -4,17 +4,17 @@ import driver
 from gui.elements.object import QObject
 
 
-class WalletToastMessage(QObject):
+class ToastMessage(QObject):
 
     def __init__(self):
-        super(WalletToastMessage, self).__init__('mainWallet_Ephemeral_Notification_List')
-        self._wallet_toast_message = QObject('ephemeralNotificationList_StatusToastMessage')
+        super(ToastMessage, self).__init__('ephemeral_Notification_List')
+        self._toast_message = QObject('ephemeralNotificationList_StatusToastMessage')
 
     @property
     @allure.step('Get toast messages')
     def get_toast_messages(self):
         messages = []
-        for obj in driver.findAllObjects(self._wallet_toast_message.real_name):
+        for obj in driver.findAllObjects(self._toast_message.real_name):
             messages.append(str(obj.primaryText))
         if len(messages) == 0:
             raise LookupError(

--- a/gui/objects_map/component_names.py
+++ b/gui/objects_map/component_names.py
@@ -281,9 +281,9 @@ testnet_mode_closeCrossButton = {"container": statusDesktop_mainWindow_overlay, 
 mainWindow_testnetBanner_ModuleWarning = {"container": statusDesktop_mainWindow, "objectName": "testnetBanner", "type": "ModuleWarning", "visible": True}
 mainWindow_Turn_off_Button = {"checkable": False, "container": statusDesktop_mainWindow, "id": "button", "text": "Turn off", "type": "Button", "unnamed": 1, "visible": True}
 
-# Wallet toast message
-mainWallet_Ephemeral_Notification_List = {"container": statusDesktop_mainWindow, "objectName": "ephemeralNotificationList", "type": "StatusListView"}
-ephemeralNotificationList_StatusToastMessage = {"container": mainWallet_Ephemeral_Notification_List, "objectName": "statusToastMessage", "type": "StatusToastMessage"}
+# Toast message
+ephemeral_Notification_List = {"container": statusDesktop_mainWindow, "objectName": "ephemeralNotificationList", "type": "StatusListView"}
+ephemeralNotificationList_StatusToastMessage = {"container": ephemeral_Notification_List, "objectName": "statusToastMessage", "type": "StatusToastMessage"}
 
 # Change password popup
 change_password_menu_current_password = {"container": statusDesktop_mainWindow_overlay, "objectName": "passwordViewCurrentPassword", "type": "StatusPasswordInput", "visible": True}

--- a/gui/objects_map/settings_names.py
+++ b/gui/objects_map/settings_names.py
@@ -34,6 +34,12 @@ mainWindow_ContactsView = {"container": statusDesktop_mainWindow, "type": "Conta
 mainWindow_Send_contact_request_to_chat_key_StatusButton = {"checkable": False, "container": mainWindow_ContactsView, "objectName": "ContactsView_ContactRequest_Button", "type": "StatusButton", "visible": True}
 contactsTabBar_Pending_Requests_StatusTabButton = {"checkable": True, "container": mainWindow_ContactsView, "objectName": "ContactsView_PendingRequest_Button", "type": "StatusTabButton", "visible": True}
 settingsContentBaseScrollView_ContactListPanel = {"container": mainWindow_ContactsView, "objectName": "ContactListPanel_ListView", "type": "StatusListView", "visible": True}
+settingsContentBaseScrollView_sentRequests_ContactsListPanel = {"container": mainWindow_ContactsView, "objectName": "sentRequests_ContactsListPanel", "type": "ContactsListPanel", "visible": True}
+contactsTabBar_Contacts_StatusTabButton = {"checkable": True, "container": mainWindow_ContactsView, "id": "contactsBtn", "type": "StatusTabButton", "unnamed": 1, "visible": True}
+settingsContentBaseScrollView_receivedRequests_ContactsListPanel = {"container": mainWindow_ContactsView, "objectName": "receivedRequests_ContactsListPanel", "type": "ContactsListPanel", "visible": True}
+settingsContentBaseScrollView_mutualContacts_ContactsListPanel = {"container": mainWindow_ContactsView, "id": "mutualContacts", "type": "ContactsListPanel", "unnamed": 1, "visible": True}
+settingsContentBaseScrollView_Invite_friends_StatusButton = {"checkable": False, "container": mainWindow_ContactsView, "type": "StatusButton", "unnamed": 1, "visible": True}
+settingsContentBaseScrollView_NoFriendsRectangle = {"container": mainWindow_ContactsView, "type": "NoFriendsRectangle", "unnamed": 1, "visible": True}
 
 # Keycard Settings View
 mainWindow_KeycardView = {"container": statusDesktop_mainWindow, "type": "KeycardView", "unnamed": 1, "visible": True}

--- a/gui/screens/settings_messaging.py
+++ b/gui/screens/settings_messaging.py
@@ -27,7 +27,7 @@ class MessagingSettingsView(QObject):
         return ContactsSettingsView().wait_until_appears()
 
 
-class PendingRequest:
+class ContactItem:
 
     def __init__(self, obj):
         self.object = obj
@@ -53,11 +53,17 @@ class PendingRequest:
                 self._reject_button = Button(name='', real_name=driver.objectMap.realName(child))
             elif str(getattr(child, 'id', '')) == 'statusListItemTitle':
                 self.contact = str(child.text)
+            elif str(getattr(child, 'objectName', '')) == 'chat-icon':
+                self._chat_button = Button(name='', real_name=driver.objectMap.realName(child))
 
     def accept(self) -> MessagesScreen:
         assert self._accept_button is not None, 'Button not found'
         self._accept_button.click()
         return MessagesScreen().wait_until_appears()
+
+    def reject(self):
+        assert self._reject_button is not None, 'Button not found'
+        self._reject_button.click()
 
 
 class ContactsSettingsView(QObject):
@@ -66,13 +72,53 @@ class ContactsSettingsView(QObject):
         super().__init__('mainWindow_ContactsView')
         self._contact_request_button = Button('mainWindow_Send_contact_request_to_chat_key_StatusButton')
         self._pending_request_tab = Button('contactsTabBar_Pending_Requests_StatusTabButton')
-        self._pending_requests_list = List('settingsContentBaseScrollView_ContactListPanel')
+        self._contacts_tab = Button('contactsTabBar_Contacts_StatusTabButton')
+        self._contacts_items_list = List('settingsContentBaseScrollView_ContactListPanel')
+        self._pending_request_sent_panel = QObject('settingsContentBaseScrollView_sentRequests_ContactsListPanel')
+        self._pending_request_received_panel = QObject(
+            'settingsContentBaseScrollView_receivedRequests_ContactsListPanel')
+        self._contacts_panel = QObject('settingsContentBaseScrollView_mutualContacts_ContactsListPanel')
+        self._invite_friends_button = QObject('settingsContentBaseScrollView_Invite_friends_StatusButton')
+        self._no_friends_item = QObject('settingsContentBaseScrollView_NoFriendsRectangle')
 
     @property
-    @allure.step('Get all pending requests')
-    def pending_requests(self) -> typing.List[PendingRequest]:
+    @allure.step('Get contact items')
+    def contact_items(self) -> typing.List[ContactItem]:
+        return [ContactItem(item) for item in self._contacts_items_list.items]
+
+
+    @property
+    @allure.step('Get title of list with sent pending requests')
+    def pending_request_sent_list_title(self) -> str:
+        return self._pending_request_sent_panel.object.title
+
+    @property
+    @allure.step('Get title of list with received pending requests')
+    def pending_request_received_list_title(self) -> str:
+        return self._pending_request_received_panel.object.title
+
+    @property
+    @allure.step('Get title of list with contacts')
+    def contacts_list_title(self) -> str:
+        return self._contacts_panel.object.title
+
+    @property
+    @allure.step('Get title of no friends item')
+    def no_friends_item_text(self) -> str:
+        return self._no_friends_item.object.text
+
+    @property
+    @allure.step('Get state of invite friends button')
+    def is_invite_friends_button_visible(self) -> bool:
+        return self._invite_friends_button.is_visible
+
+    @allure.step('Open pending requests tab')
+    def open_pending_requests(self):
         self._pending_request_tab.click()
-        return [PendingRequest(item) for item in self._pending_requests_list.items]
+
+    @allure.step('Open contacts tab')
+    def open_contacts(self):
+        self._contacts_tab.click()
 
     @allure.step('Open contacts request form')
     def open_contact_request_form(self) -> SendContactRequest:
@@ -84,15 +130,27 @@ class ContactsSettingsView(QObject):
         LeftPanel().open_messaging_settings().open_contacts_settings().open_contact_request_form()
 
     @allure.step('Accept contact request')
-    def accept_contact_request(
-            self, contact: str, timeout_sec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC) -> MessagesScreen:
-        self._pending_request_tab.click()
+    def find_contact_in_list(
+            self, contact: str, timeout_sec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC):
+        self.open_pending_requests()
         started_at = time.monotonic()
         request = None
         while request is None:
-            requests = self.pending_requests
+            requests = self.contact_items
             for _request in requests:
                 if _request.contact == contact:
                     request = _request
             assert time.monotonic() - started_at < timeout_sec, f'Contact: {contact} not found in {requests}'
+        return request
+
+    @allure.step('Accept contact request')
+    def accept_contact_request(self, contact: str,
+                               timeout_sec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC) -> MessagesScreen:
+        request = self.find_contact_in_list(contact, timeout_sec)
         return request.accept()
+
+    @allure.step('Reject contact request')
+    def reject_contact_request(
+            self, contact: str, timeout_sec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC):
+        request = self.find_contact_in_list(contact, timeout_sec)
+        request.reject()

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -13,14 +13,13 @@ from gui.components.wallet.popup_delete_account_from_settings import RemoveAccou
 from gui.components.wallet.testnet_mode_popup import TestnetModePopup
 
 from gui.components.wallet.wallet_account_popups import AccountPopup, EditAccountFromSettingsPopup
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.elements.button import Button
 from gui.elements.check_box import CheckBox
 from gui.elements.object import QObject
 from gui.elements.scroll import Scroll
 from gui.elements.text_edit import TextEdit
 from gui.elements.text_label import TextLabel
-from scripts.tools.image import Image
 
 
 class WalletSettingsView(QObject):
@@ -264,15 +263,15 @@ class EditNetworkSettings(WalletSettingsView):
     def check_toast_message(self, network_tab):
         match network_tab:
             case WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
-                assert len(WalletToastMessage().get_toast_messages) == 1, \
+                assert len(ToastMessage().get_toast_messages) == 1, \
                     f"Multiple toast messages appeared"
-                message = WalletToastMessage().get_toast_messages[0]
+                message = ToastMessage().get_toast_messages[0]
                 assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value, \
                     f"Toast message is incorrect, current message is {message}"
             case WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
-                assert len(WalletToastMessage().get_toast_messages) == 1, \
+                assert len(ToastMessage().get_toast_messages) == 1, \
                     f"Multiple toast messages appeared"
-                message = WalletToastMessage().get_toast_messages[0]
+                message = ToastMessage().get_toast_messages[0]
                 assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_TEST_MAINNET_TOAST_MESSAGE.value, \
                     f"Toast message is incorrect, current message is {message}"
 

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -5,7 +5,7 @@ from allure_commons._allure import step
 import configs.testpath
 import constants
 from constants import UserAccount
-from constants.group_chat import GroupChatMessages
+from constants.messaging import Messaging
 from gui.main_window import MainWindow
 from gui.screens.messages import MessagesScreen
 
@@ -99,7 +99,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
                 assert messages_screen.group_chat.group_name == group_chat_name, f'Group chat name is not correct'
             with step('Welcome group message is correct'):
                 actual_welcome_message = messages_screen.group_chat.group_welcome_message
-                assert actual_welcome_message.startswith(GroupChatMessages.WELCOME_GROUP_MESSAGE.value)
+                assert actual_welcome_message.startswith(Messaging.WELCOME_GROUP_MESSAGE.value)
                 assert actual_welcome_message.endswith(' group!')
                 assert group_chat_name in actual_welcome_message
             with step('Verify there are three members in group members list'):

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_reject_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_reject_request.py
@@ -1,0 +1,153 @@
+import allure
+import pytest
+from allure_commons._allure import step
+
+import configs.testpath
+import constants
+from constants import UserAccount
+from constants.messaging import Messaging
+from gui.components.toast_message import ToastMessage
+from gui.main_window import MainWindow
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703011', 'Add a contact with a chat key')
+@pytest.mark.case(703011)
+@pytest.mark.parametrize('user_data_one, user_data_two', [
+    (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
+])
+def test_messaging_settings_accepting_request(multiple_instance, user_data_one, user_data_two):
+    user_one: UserAccount = constants.user_account_one
+    user_two: UserAccount = constants.user_account_two
+    main_window = MainWindow()
+
+    with multiple_instance() as aut_one, multiple_instance() as aut_two:
+        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
+            for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
+                aut.attach()
+                main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
+                main_window.authorize_user(account)
+                main_window.hide()
+
+        with step(f'User {user_two.name}, get chat key'):
+            aut_two.attach()
+            main_window.prepare()
+            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            chat_key = profile_popup.chat_key
+            profile_popup.close()
+            main_window.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contact_request_popup = contacts_settings.open_contact_request_form()
+            contact_request_popup.send(chat_key, f'Hello {user_two.name}')
+
+        with step('Verify that contact request was sent and is in pending requests'):
+            contacts_settings.open_pending_requests()
+            assert Messaging.CONTACT_REQUEST_SENT.value == contacts_settings.contact_items[0].object.contactText
+            assert len(contacts_settings.contact_items) == 1
+            assert contacts_settings.pending_request_sent_list_title == 'Sent'
+            main_window.hide()
+
+        with step(f'Verify that contact request was received by {user_two.name}'):
+            aut_two.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contacts_settings.open_pending_requests()
+            assert contacts_settings.pending_request_received_list_title == 'Received'
+            assert user_one.name == contacts_settings.contact_items[0].contact
+            assert len(contacts_settings.contact_items) == 1
+
+        with step('Verify toast message about new contact request received'):
+            assert len(ToastMessage().get_toast_messages) == 1, \
+                f"Multiple toast messages appeared"
+            message = ToastMessage().get_toast_messages[0]
+            assert message == Messaging.NEW_CONTACT_REQUEST.value, \
+                f"Toast message is incorrect, current message is {message}"
+
+        with step(f'User {user_two.name}, accept contact request from {user_one.name}'):
+            contacts_settings.accept_contact_request(user_one.name)
+
+        with step(f'Verify that contact appeared in contacts list of {user_two.name} in messaging settings'):
+            contacts_settings = main_window.left_panel.open_settings().left_panel.open_messaging_settings().open_contacts_settings()
+            contacts_settings.open_contacts()
+            assert contacts_settings.contacts_list_title == 'Contacts'
+            assert user_one.name == contacts_settings.contact_items[0].contact
+            assert len(contacts_settings.contact_items) == 1
+            main_window.hide()
+
+        with step(f'Verify that contact appeared in contacts list of {user_one.name} in messaging settings'):
+            aut_one.attach()
+            main_window.prepare()
+            contacts_settings = main_window.left_panel.open_settings().left_panel.open_messaging_settings().open_contacts_settings()
+            contacts_settings.open_contacts()
+            assert contacts_settings.contacts_list_title == 'Contacts'
+            assert user_two.name == contacts_settings.contact_items[0].contact
+            assert len(contacts_settings.contact_items) == 1
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704610', 'Reject a contact request with a chat key')
+@pytest.mark.case(704610)
+@pytest.mark.parametrize('user_data_one, user_data_two', [
+    (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
+])
+def test_messaging_settings_rejecting_request(multiple_instance, user_data_one, user_data_two):
+    user_one: UserAccount = constants.user_account_one
+    user_two: UserAccount = constants.user_account_two
+    main_window = MainWindow()
+
+    with multiple_instance() as aut_one, multiple_instance() as aut_two:
+        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
+            for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
+                aut.attach()
+                main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
+                main_window.authorize_user(account)
+                main_window.hide()
+
+        with step(f'User {user_two.name}, get chat key'):
+            aut_two.attach()
+            main_window.prepare()
+            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            chat_key = profile_popup.chat_key
+            profile_popup.close()
+            main_window.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contact_request_popup = contacts_settings.open_contact_request_form()
+            contact_request_popup.send(chat_key, f'Hello {user_two.name}')
+
+            main_window.hide()
+
+        with step(f'Verify that contact request from user {user_two.name} was received and reject contact request'):
+            aut_two.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contacts_settings.open_pending_requests()
+            contacts_settings.reject_contact_request(user_one.name)
+
+        with step(f'Verify that contacts list of {user_two.name} is empty in messaging settings'):
+            contacts_settings = main_window.left_panel.open_settings().left_panel.open_messaging_settings().open_contacts_settings()
+            contacts_settings.open_contacts()
+            assert contacts_settings.no_friends_item_text == Messaging.NO_FRIENDS_ITEM.value
+            assert contacts_settings.is_invite_friends_button_visible
+            main_window.hide()
+
+        with step(f'Verify that contacts list of {user_one.name} is empty in messaging settings'):
+            aut_one.attach()
+            main_window.prepare()
+            contacts_settings = main_window.left_panel.open_settings().left_panel.open_messaging_settings().open_contacts_settings()
+            contacts_settings.open_contacts()
+            assert contacts_settings.no_friends_item_text == Messaging.NO_FRIENDS_ITEM.value
+            assert contacts_settings.is_invite_friends_button_visible

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -1,6 +1,5 @@
 import random
 import string
-import time
 
 import allure
 import pytest
@@ -11,7 +10,7 @@ import driver
 from constants.wallet import WalletAccountSettings, DerivationPath
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 from gui.screens.settings_wallet import WalletSettingsView
 
@@ -61,7 +60,7 @@ def test_delete_generated_account_from_wallet_settings(
         delete_confirmation_popup.click_remove_account_button()
 
     with step('Verify toast message notification when removing account'):
-        messages = WalletToastMessage().get_toast_messages
+        messages = ToastMessage().get_toast_messages
         assert f'"{account_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -9,7 +9,7 @@ from allure_commons._allure import step
 import constants
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 
@@ -34,9 +34,9 @@ def test_add_new_account_from_wallet_settings(
         add_account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{account_name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list on main wallet screen'):

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
@@ -5,7 +5,7 @@ from allure import step
 import configs.system
 from constants.wallet import WalletNetworkSettings, WalletNetworkNaming
 from gui.components.wallet.testnet_mode_banner import TestnetModeBanner
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 
@@ -29,9 +29,9 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().click_turn_on_testnet_mode_in_testnet_modal()
 
     with step('Verify that Testnet mode turned on'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE:
@@ -51,8 +51,8 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().turn_off_testnet_mode_in_testnet_modal()
 
     with step('Verify that Testnet mode turned off'):
-        assert len(WalletToastMessage().get_toast_messages) == 2
-        message = WalletToastMessage().get_toast_messages[1]
+        assert len(ToastMessage().get_toast_messages) == 2
+        message = ToastMessage().get_toast_messages[1]
         assert message == WalletNetworkSettings.TESTNET_DISABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE:
@@ -81,7 +81,7 @@ def test_toggle_testnet_toggle_on_and_close_the_confirmation(main_screen: MainWi
         assert not networks.is_testnet_mode_toggle_checked()
 
     with step('Verify that Testnet mode is not turned off'):
-        assert not WalletToastMessage().is_visible
+        assert not ToastMessage().is_visible
         if not configs.system.TEST_MODE:
             assert not TestnetModeBanner().is_visible, f"Testnet banner is present when it should not"
         assert not networks.is_testnet_mode_toggle_checked(), \
@@ -104,9 +104,9 @@ def test_switch_testnet_off_by_toggle_and_cancel_in_confirmation(main_screen: Ma
         testnet_modal.click_turn_on_testnet_mode_in_testnet_modal()
 
     with step('Verify testnet mode is enabled'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE:

--- a/tests/wallet_main_screen/test_wallet_main_can_add_account_after_restart.py
+++ b/tests/wallet_main_screen/test_wallet_main_can_add_account_after_restart.py
@@ -5,11 +5,10 @@ import pytest
 from allure import step
 
 import constants
-import driver
 from driver.aut import AUT
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 
@@ -39,9 +38,9 @@ def test_add_generated_account_restart_add_again(
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -66,9 +65,9 @@ def test_add_generated_account_restart_add_again(
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name2}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
+++ b/tests/wallet_main_screen/test_wallet_main_manage_accounts.py
@@ -8,7 +8,7 @@ import constants
 import driver
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 from gui.screens.settings_keycard import KeycardSettingsView
 
@@ -63,9 +63,9 @@ def test_manage_watch_only_account_context_menu(main_screen: MainWindow, address
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Edit wallet account'):
@@ -101,9 +101,9 @@ def test_manage_generated_account(main_screen: MainWindow, user_account,
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -130,7 +130,7 @@ def test_manage_generated_account(main_screen: MainWindow, user_account,
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = WalletToastMessage().get_toast_messages
+        messages = ToastMessage().get_toast_messages
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
@@ -162,9 +162,9 @@ def test_manage_custom_generated_account(main_screen: MainWindow, user_account,
                                                                                            user_account.password).save()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -179,7 +179,7 @@ def test_manage_custom_generated_account(main_screen: MainWindow, user_account,
         wallet.left_panel.delete_account_from_context_menu(name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = WalletToastMessage().get_toast_messages
+        messages = ToastMessage().get_toast_messages
         assert f'"{name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
@@ -210,9 +210,9 @@ def test_private_key_imported_account(main_screen: MainWindow, user_account, add
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -247,7 +247,7 @@ def test_private_key_imported_account(main_screen: MainWindow, user_account, add
         wallet.left_panel.delete_account_from_context_menu(new_name).confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = WalletToastMessage().get_toast_messages
+        messages = ToastMessage().get_toast_messages
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
@@ -287,9 +287,9 @@ def test_seed_phrase_imported_account(main_screen: MainWindow, user_account,
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -316,7 +316,7 @@ def test_seed_phrase_imported_account(main_screen: MainWindow, user_account,
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = WalletToastMessage().get_toast_messages
+        messages = ToastMessage().get_toast_messages
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 
@@ -346,9 +346,9 @@ def test_seed_phrase_generated_account(main_screen: MainWindow, user_account,
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -375,7 +375,7 @@ def test_seed_phrase_generated_account(main_screen: MainWindow, user_account,
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = WalletToastMessage().get_toast_messages
+        messages = ToastMessage().get_toast_messages
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/wallet_main_screen/test_wlt_main_add_acc_manage_watched_address.py
+++ b/tests/wallet_main_screen/test_wlt_main_add_acc_manage_watched_address.py
@@ -5,10 +5,9 @@ import pytest
 from allure_commons._allure import step
 
 import constants
-import driver
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.wallet.wallet_toast_message import WalletToastMessage
+from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 
@@ -33,9 +32,9 @@ def test_wallet_add_acc_add_watched_address(
             f"Authentication should not appear for adding watched addresses"
 
     with step('Verify toast message notification when adding account'):
-        assert len(WalletToastMessage().get_toast_messages) == 1, \
+        assert len(ToastMessage().get_toast_messages) == 1, \
             f"Multiple toast messages appeared"
-        message = WalletToastMessage().get_toast_messages[0]
+        message = ToastMessage().get_toast_messages[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):


### PR DESCRIPTION
I also changed in this task class for toast messages, because I use it in messaging settings tests and  it's not only for wallet anymore

CI report: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1109/

Allure report locally:

<img width="1133" alt="Screenshot 2023-11-23 at 22 35 55" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/d64e4bd6-aba9-482b-811b-12810484bde2">
