### PR TITLE
chore: fix sign out test

### DIFF
--- a/gui/components/settings/sign_out_popup.py
+++ b/gui/components/settings/sign_out_popup.py
@@ -1,0 +1,15 @@
+import allure
+
+from gui.components.base_popup import BasePopup
+from gui.elements.button import Button
+
+
+class SignOutPopup(BasePopup):
+
+    def __init__(self):
+        super().__init__()
+        self._sign_out_and_quit_button = Button('signOutConfirmationButton')
+
+    @allure.step('Click sign out and quit button')
+    def sign_out_and_quit(self):
+        self._sign_out_and_quit_button.click()

--- a/gui/objects_map/settings_names.py
+++ b/gui/objects_map/settings_names.py
@@ -130,3 +130,6 @@ settings_Setup_Syncing_StatusButton = {"container": statusDesktop_mainWindow, "o
 settings_Backup_Data_StatusButton = {"container": settingsContentBase_ScrollView, "objectName": "setupSyncBackupDataButton", "type": "StatusButton", "visible": True}
 settings_Sync_New_Device_Header = {"container": settingsContentBase_ScrollView, "objectName": "syncNewDeviceTextLabel", "type": "StatusBaseText", "visible": True}
 settings_Sync_New_Device_SubTitle = {"container": settingsContentBase_ScrollView, "objectName": "syncNewDeviceSubTitleTextLabel", "type": "StatusBaseText", "visible": True}
+
+#Sing out and quit View
+signOutConfirmationButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "signOutConfirmation", "type": "StatusButton", "visible": True}

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -9,6 +9,7 @@ from gui.screens.settings_messaging import MessagingSettingsView
 from gui.screens.settings_profile import ProfileSettingsView
 from gui.screens.settings_syncing import SyncingSettingsView
 from gui.screens.settings_wallet import WalletSettingsView
+from gui.components.settings.sign_out_popup import SignOutPopup
 
 
 class LeftPanel(QObject):
@@ -66,8 +67,9 @@ class LeftPanel(QObject):
                 raise f"Sync settings was not opened"
 
     @allure.step('Choose sign out and quit in settings')
-    def sign_out_and_quit(self):
+    def open_sign_out_and_quit(self):
         self._open_settings('16-ExtraMenuItem')
+        return SignOutPopup()
 
     @allure.step('Open keycard settings')
     def open_keycard_settings(self):

--- a/tests/settings/test_sign_out_and_quit.py
+++ b/tests/settings/test_sign_out_and_quit.py
@@ -13,7 +13,8 @@ def test_sign_out_and_quit(aut, main_screen: MainWindow):
         settings = main_screen.left_panel.open_settings()
 
     with step('Click sign out and quit in settings'):
-        settings.left_panel.sign_out_and_quit()
+        sign_out_screen = settings.left_panel.open_sign_out_and_quit()
+        sign_out_screen.sign_out_and_quit()
 
     with step('Check that app was closed'):
         wait_for_close(aut.pid)


### PR DESCRIPTION
Added a click to the Sign out button, which was not present

CI run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1179/

<img width="1840" alt="Screenshot 2023-11-30 at 22 42 09" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/5d5f5b83-09b3-43ef-9747-967f31215048">
