### PR TITLE
chore: removed skip mark from syncing and messaging tests

### DIFF
--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -33,7 +33,6 @@ def sync_screen(main_window) -> SyncCodeView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703592', 'Sync device during onboarding')
 @pytest.mark.case(703592)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'user_account_one'])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/350")
 def test_sync_device_during_onboarding(multiple_instance, user_data):
     user: UserAccount = constants.user_account_one
     main_window = MainWindow()

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_reject_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_reject_request.py
@@ -15,7 +15,6 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12889")
 def test_messaging_settings_accepting_request(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
@@ -16,7 +16,6 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12889")
 def test_messaging_settings_identity_verification(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two


### PR DESCRIPTION
I ran these tests and they are passing now locally and on CI
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1188/
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1189/
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1191/

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1192/