### PR TITLE
chore: add timeout and assert for the sign out test

### DIFF
--- a/tests/settings/test_settings_sign_out_and_quit.py
+++ b/tests/settings/test_settings_sign_out_and_quit.py
@@ -16,4 +16,5 @@ def test_sign_out_and_quit(aut, main_screen: MainWindow):
         sign_out_screen.sign_out_and_quit()
 
     with step('Check that app was closed'):
-        psutil.Process(aut.pid).wait()
+        psutil.Process(aut.pid).wait(timeout=5)
+        assert aut.pid not in psutil.pids(), f"{aut.pid} is still running"


### PR DESCRIPTION
Reason to do that: https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/112/allure/

The verification was waiting for 1h

<img width="2032" alt="Screenshot 2023-12-04 at 14 42 15" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/dbdc5c43-ecdd-4721-a09c-fe858c7959a9">
