### PR TITLE
fix(aut): detach own context, not current one

### DIFF
--- a/configs/squish.py
+++ b/configs/squish.py
@@ -1,5 +1,5 @@
 import os
 
-AUT_PORT = 61500 + int(os.getenv('BUILD_NUMBER', 0))
-SERVER_PORT = 4322 + int(os.getenv('BUILD_NUMBER', 0))
+AUT_PORT = 61500 + int(os.getenv('EXECUTOR_NUMBER', 0)) * 100
+SERVER_PORT = 4322 + int(os.getenv('EXECUTOR_NUMBER', 0)) * 100
 CURSOR_ANIMATION = False

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -100,7 +100,7 @@ class AUT:
     @allure.step('Start AUT')
     def startaut(self):
         LOG.info('Launching AUT: %s', self.path)
-        self.port = local_system.find_free_port(configs.squish.AUT_PORT, 100)
+        self.port = local_system.find_free_port(configs.squish.AUT_PORT, 10)
         command = [
             str(configs.testpath.SQUISH_DIR / 'bin/startaut'),
             f'--port={self.port}',

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -68,10 +68,10 @@ class AUT:
 
         self.stop()
 
-    def detach_context(self):
+    def detach(self):
         if self.ctx is None:
             return
-        squish.currentApplicationContext().detach()
+        self.ctx.detach()
         self.ctx = None
 
     def kill_process(self):
@@ -121,7 +121,7 @@ class AUT:
     @allure.step('Close application')
     def stop(self):
         LOG.info('Stoping AUT: %s', self.path)
-        self.detach_context()
+        self.detach()
         self.kill_process()
 
     @allure.step("Start and attach AUT")

--- a/driver/server.py
+++ b/driver/server.py
@@ -25,7 +25,7 @@ class SquishServer:
 
     @classmethod
     def start(cls):
-        cls.port = local_system.find_free_port(configs.squish.SERVER_PORT, 100)
+        cls.port = local_system.find_free_port(configs.squish.SERVER_PORT, 10)
         LOG.info('Starting Squish Server on port: %d', cls.port)
         cmd = [
             str(cls.path),


### PR DESCRIPTION
Seems wrong to me. My understanding is that context is specific to given AUT being run.