### PR TITLE
chore: communities tests enabled and fixed, replaced image comparison

### DIFF
--- a/constants/user.py
+++ b/constants/user.py
@@ -33,7 +33,7 @@ community_params = {
 }
 
 UserCommunityInfo = namedtuple('CommunityInfo', ['name', 'description', 'members', 'image'])
-UserChannel = namedtuple('Channel', ['name', 'image', 'selected'])
+UserChannel = namedtuple('Channel', ['name', 'selected'])
 
 account_list_item = namedtuple('AccountListItem', ['name', 'color', 'emoji'])
 wallet_account_list_item = namedtuple('WalletAccountListItem', ['name', 'icon_color', 'icon_emoji', 'object'])

--- a/gui/components/community/welcome_community.py
+++ b/gui/components/community/welcome_community.py
@@ -17,6 +17,8 @@ class WelcomeCommunityPopup(BasePopup):
         self._intro_text_label = TextLabel('intro_StatusBaseText')
         self._select_address_button = Button('select_addresses_to_share_StatusFlatButton')
         self._join_button = Button('join_StatusButton')
+        self._authenticate_button = Button('welcome_authenticate_StatusButton')
+        self._share_address_button = Button('share_your_addresses_to_join_StatusButton')
 
     @property
     @allure.step('Get title')
@@ -36,4 +38,8 @@ class WelcomeCommunityPopup(BasePopup):
     @allure.step('Join community')
     def join(self) -> AuthenticatePopup:
         self._join_button.click()
+        self._authenticate_button.click()
         return AuthenticatePopup().wait_until_appears()
+
+    def share_address(self):
+        self._share_address_button.click()

--- a/gui/objects_map/community_names.py
+++ b/gui/objects_map/community_names.py
@@ -22,8 +22,7 @@ channel_identicon_StatusSmartIdenticon = {"container": None, "id": "identicon", 
 channel_name_StatusBaseText = {"container": None, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 mainWindow_createChannelOrCategoryBtn_StatusBaseText = {"container": mainWindow_communityColumnView_CommunityColumnView, "objectName": "createChannelOrCategoryBtn", "type": "StatusBaseText", "visible": True}
 create_channel_StatusMenuItem = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": "createCommunityChannelBtn", "type": "StatusMenuItem", "visible": True}
-mainWindow_Join_Community_StatusButton = {"checkable": False, "container": mainWindow_communityColumnView_CommunityColumnView, "id": "joinCommunityButton", "text": "Join Community", "type": "StatusButton", "unnamed": 1, "visible": True}
-
+mainWindow_Join_Community_StatusButton = {"checkable": False, "container": mainWindow_StatusWindow, "type": "StatusButton", "unnamed": 1, "visible": True}
 add_categories_StatusFlatButton = {"checkable": False, "container": mainWindow_scrollView_StatusScrollView, "id": "manageBtn", "type": "StatusFlatButton", "visible": True}
 categoryItem_StatusChatListCategoryItem = {"container": mainWindow_scrollView_StatusScrollView, "objectName": "categoryItem", "type": "StatusChatListCategoryItem", "visible": True}
 delete_Category_StatusMenuItem = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": "deleteCategoryMenuItem", "type": "StatusMenuItem", "visible": True}
@@ -40,12 +39,15 @@ edit_Channel_StatusMenuItem = {"checkable": False, "container": statusDesktop_ma
 statusToolBar_statusSmartIdenticonLetter_StatusLetterIdenticon = {"container": mainWindow_statusToolBar_StatusToolBar, "objectName": "statusSmartIdenticonLetter", "type": "StatusLetterIdenticon", "visible": True}
 statusToolBar_statusChatInfoButtonNameText_TruncatedTextWithTooltip = {"container": mainWindow_statusToolBar_StatusToolBar, "objectName": "statusChatInfoButtonNameText", "type": "TruncatedTextWithTooltip", "visible": True}
 statusToolBar_TruncatedTextWithTooltip = {"container": mainWindow_statusToolBar_StatusToolBar, "type": "TruncatedTextWithTooltip", "unnamed": 1, "visible": True}
+statusToolBar_chatInfoBtnInHeader_StatusChatInfoButton = {"checkable": False, "container": mainWindow_statusToolBar_StatusToolBar, "objectName": "chatInfoBtnInHeader", "type": "StatusChatInfoButton",  "visible": True}
 
 # Chat
+mainWindow_ChatMessagesView = {"container": mainWindow_StatusWindow, "type": "ChatMessagesView", "unnamed": 1, "visible": True}
 mainWindow_ChatColumnView = {"container": mainWindow_communityLoader_Loader, "type": "ChatColumnView", "unnamed": 1, "visible": True}
 chatMessageViewDelegate_channelIdentifierNameText_StyledText = {"container": mainWindow_ChatColumnView, "objectName": "channelIdentifierNameText", "type": "StyledText", "visible": True}
 chatMessageViewDelegate_Welcome = {"container": mainWindow_ChatColumnView, "type": "StatusBaseText", "unnamed": 1, "visible": True}
-chatMessageViewDelegate_channelIdentifierSmartIdenticon_StatusSmartIdenticon = {"container": mainWindow_ChatColumnView, "objectName": "channelIdentifierSmartIdenticon", "type": "StatusSmartIdenticon", "visible": True}
+chatMessageViewDelegate_channelIdentifierSmartIdenticon_StatusSmartIdenticon = {"container": mainWindow_ChatMessagesView, "objectName": "channelIdentifierSmartIdenticon", "type": "StatusSmartIdenticon", "visible": True}
+chatMessageViewDelegate_ChannelIdentifierView = {"container": mainWindow_ChatMessagesView, "type": "ChannelIdentifierView", "unnamed": 1, "visible": True}
 
 # Community Settings
 mainWindow_communitySettingsBackToCommunityButton_StatusBaseText = {"container": mainWindow_communityLoader_Loader, "objectName": "communitySettingsBackToCommunityButton", "type": "StatusBaseText", "visible": True}

--- a/gui/objects_map/component_names.py
+++ b/gui/objects_map/component_names.py
@@ -117,11 +117,14 @@ send_1_invite_StatusButton = {"checkable": False, "container": statusDesktop_mai
 o_StatusMemberListItem_2 = {"container": communityProfilePopupInviteMessagePanel, "type": "StatusMemberListItem", "unnamed": 1, "visible": True}
 
 # Welcome community
+o_ColumnLayout = {"container": statusDesktop_mainWindow_overlay, "type": "ColumnLayout", "unnamed": 1, "visible": True}
 headerTitle_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle", "type": "StatusBaseText", "visible": True}
 image_StatusImage = {"container": statusDesktop_mainWindow_overlay, "id": "image", "type": "StatusImage", "unnamed": 1, "visible": True}
-intro_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "text": "Intro", "type": "StatusBaseText", "unnamed": 1, "visible": True}
+intro_StatusBaseText = {"container": o_ColumnLayout, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 select_addresses_to_share_StatusFlatButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusFlatButton", "unnamed": 1, "visible": True}
 join_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+welcome_authenticate_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "text": "Authenticate", "unnamed": 1, "visible": True}
+share_your_addresses_to_join_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
 
 """ Settings """
 

--- a/gui/objects_map/settings_names.py
+++ b/gui/objects_map/settings_names.py
@@ -20,9 +20,8 @@ settingsContentBaseScrollView_listItem_StatusListItem = {"container": mainWindow
 
 # Templates to generate Real Name in test
 settings_iconOrImage_StatusSmartIdenticon = {"id": "iconOrImage", "type": "StatusSmartIdenticon", "unnamed": 1, "visible": True}
-settings_Name_StatusTextWithLoadingState = {"type": "StatusTextWithLoadingState", "unnamed": 1, "visible": True}
+settings_StatusTextWithLoadingState = {"type": "StatusTextWithLoadingState", "unnamed": 1, "visible": True}
 settings_statusListItemSubTitle = {"objectName": "statusListItemSubTitle", "type": "StatusTextWithLoadingState", "visible": True}
-settings_member_StatusTextWithLoadingState = {"text": "1 member", "type": "StatusTextWithLoadingState", "unnamed": 1, "visible": True}
 settings_StatusFlatButton = {"type": "StatusFlatButton", "unnamed": 1, "visible": True}
 
 # Messaging View

--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -46,21 +46,24 @@ class CommunityScreen(QObject):
 
     @allure.step('Verify channel')
     def verify_channel(
-            self, name: str, description: str, icon_in_list: str, icon_in_toolbar: str, icon_in_chat: str):
+            self, name: str, description: str, emoji, color: str):
         with step('Channel is correct in channels list'):
             channel = self.left_panel.get_channel_parameters(name)
-            image.compare(channel.image, icon_in_list, timout_sec=5)
             assert channel.name == name
             assert channel.selected
 
         with step('Channel is correct in community toolbar'):
             assert self.tool_bar.channel_name == name
             assert self.tool_bar.channel_description == description
-            image.compare(self.tool_bar.channel_icon, icon_in_toolbar, timout_sec=5)
+            if emoji is not None:
+                assert self.tool_bar.channel_emoji == emoji
+            assert self.tool_bar.channel_color == color
 
         with step('Verify channel in chat'):
             assert self.chat.channel_name == name
-            image.compare(self.chat.channel_icon, icon_in_chat, timout_sec=5)
+            if emoji is not None:
+                assert self.chat.channel_emoji == emoji
+            assert self.chat.channel_color == color
 
     @allure.step('Create category')
     def create_category(self, name: str, general_checkbox: bool):
@@ -88,11 +91,18 @@ class ToolBar(QObject):
         self._channel_name = TextLabel('statusToolBar_statusChatInfoButtonNameText_TruncatedTextWithTooltip')
         self._channel_description = TextLabel('statusToolBar_TruncatedTextWithTooltip')
         self._delete_channel_context_item = QObject('delete_Channel_StatusMenuItem')
+        self._channel_header = QObject('statusToolBar_chatInfoBtnInHeader_StatusChatInfoButton')
+
 
     @property
-    @allure.step('Get channel icon')
-    def channel_icon(self) -> Image:
-        return self._channel_icon.image
+    @allure.step('Get channel emoji')
+    def channel_emoji(self):
+        return self._channel_header.object.asset.emoji
+
+    @property
+    @allure.step('Get channel color')
+    def channel_color(self) -> str:
+        return str(self._channel_header.object.asset.color.name).lower()
 
     @property
     @allure.step('Get channel name')
@@ -197,7 +207,6 @@ class LeftPanel(QObject):
             self._channel_icon_template.real_name['container'] = container
             channels_list.append(UserChannel(
                 str(obj.objectName),
-                self._channel_icon_template.image,
                 obj.item.selected
             ))
         return channels_list
@@ -281,11 +290,18 @@ class Chat(QObject):
         self._channel_icon = QObject('chatMessageViewDelegate_channelIdentifierSmartIdenticon_StatusSmartIdenticon')
         self._channel_name_label = TextLabel('chatMessageViewDelegate_channelIdentifierNameText_StyledText')
         self._channel_welcome_label = TextLabel('chatMessageViewDelegate_Welcome')
+        self._channel_identifier_view = QObject('chatMessageViewDelegate_ChannelIdentifierView')
+
 
     @property
-    @allure.step('Get channel icon')
-    def channel_icon(self) -> Image:
-        return self._channel_icon.image
+    @allure.step('Get channel emoji')
+    def channel_emoji(self):
+        return self._channel_identifier_view.object.chatEmoji
+
+    @property
+    @allure.step('Get channel color')
+    def channel_color(self) -> str:
+        return str(self._channel_identifier_view.object.chatColor).lower()
 
     @property
     @allure.step('Get channel name')

--- a/gui/screens/settings_communities.py
+++ b/gui/screens/settings_communities.py
@@ -22,9 +22,8 @@ class CommunitiesSettingsView(QObject):
         super().__init__('mainWindow_CommunitiesView')
         self._community_item = QObject('settingsContentBaseScrollView_listItem_StatusListItem')
         self._community_template_image = QObject('settings_iconOrImage_StatusSmartIdenticon')
-        self._community_template_name = TextLabel('settings_Name_StatusTextWithLoadingState')
+        self._community_template_name_members = QObject('settings_StatusTextWithLoadingState')
         self._community_template_description = TextLabel('settings_statusListItemSubTitle')
-        self._community_template_members = TextLabel('settings_member_StatusTextWithLoadingState')
         self._community_template_button = Button('settings_StatusFlatButton')
 
     @property
@@ -34,17 +33,16 @@ class CommunitiesSettingsView(QObject):
         for obj in driver.findAllObjects(self._community_item.real_name):
             container = driver.objectMap.realName(obj)
             self._community_template_image.real_name['container'] = container
-            self._community_template_name.real_name['container'] = container
+            self._community_template_name_members.real_name['container'] = container
             self._community_template_description.real_name['container'] = container
-            self._community_template_members.real_name['container'] = container
 
-            name = self._community_template_name.text
             description = self._community_template_description.text
-            try:
-                members = self._community_template_members.text
-            except LookupError as err:
-                LOG.info(err)
-                members = 0
+            name_members_labels = []
+            for item in driver.findAllObjects(self._community_template_name_members.real_name):
+                name_members_labels.append(item)
+            sorted(name_members_labels, key=lambda item: item.y)
+            name = str(name_members_labels[0].text)
+            members = str(name_members_labels[1].text)
             image = self._community_template_image.image
 
             _communities.append(UserCommunityInfo(name, description, members, image))

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -10,7 +10,6 @@ import constants
 import driver
 from constants import UserAccount
 from gui.main_window import MainWindow
-from scripts.tools import image
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703084', 'Create community')
@@ -23,17 +22,10 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         community_screen = create_community_form.create(params)
 
     with step('Verify community parameters in community overview'):
-        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
-        # with step('Icon is correct'):
-        # community_icon = main_screen.left_panel.get_community_logo(params['name'])
-        # image.compare(community_icon, 'button_logo.png', timout_sec=5)
         with step('Name is correct'):
             assert community_screen.left_panel.name == params['name']
         with step('Members count is correct'):
             assert '1' in community_screen.left_panel.members
-        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
-        # with step('Logo is correct'):
-        # image.compare(community_screen.left_panel.logo, 'logo.png')
 
     with step('Verify community parameters in community settings view'):
         community_setting = community_screen.left_panel.open_community_settings()
@@ -53,8 +45,6 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         assert community.name == params['name']
         assert community.description == params['description']
         # assert '1' in community.members TODO: Test on linux, members label is not visible
-        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
-        # image.compare(community.image, 'logo_in_settings.png')
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703056', 'Edit community separately')
@@ -65,9 +55,7 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         'description': f'Description_{datetime.now():%H%M%S}',
         'color': '#ff7d46',
     },
-
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
 def test_edit_community_separately(main_screen, community_params):
     main_screen.create_community(constants.community_params)
 
@@ -108,7 +96,6 @@ def test_edit_community_separately(main_screen, community_params):
         'outro': 'Updated Outro'
     }
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
 def test_edit_community(main_screen: MainWindow, params):
     main_screen.create_community(constants.community_params)
 
@@ -127,15 +114,8 @@ def test_edit_community(main_screen: MainWindow, params):
 
     with step('Verify community parameters in community screen'):
         community_setting.left_panel.back_to_community()
-        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
-        # with step('Icon is correct'):
-        #     community_icon = main_screen.left_panel.get_community_logo(params['name'])
-        # image.compare(community_icon, 'button_updated_logo.png')
         with step('Name is correct'):
             assert community_screen.left_panel.name == params['name']
-        # TODO: change image comparison https://github.com/status-im/desktop-qa-automation/issues/263
-        # with step('Logo is correct'):
-        # image.compare(community_screen.left_panel.logo, 'updated_logo.png')
 
     with step('Verify community parameters in community settings screen'):
         settings_screen = main_screen.left_panel.open_settings()
@@ -143,8 +123,8 @@ def test_edit_community(main_screen: MainWindow, params):
         community_info = community_settings.communities[0]
         assert community_info.name == params['name']
         assert community_info.description == params['description']
-        assert '1' in community_info.members
-        # image.compare(community_info.image, 'logo_in_settings_updated.png')
+        # TODO after https://github.com/status-im/status-desktop/issues/12967 will be fixed
+        # assert '1' in community_info.members
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703510', 'Join community via owner invite')
@@ -152,7 +132,6 @@ def test_edit_community(main_screen: MainWindow, params):
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
 def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two
@@ -214,6 +193,7 @@ def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_
             assert community_params['name'] in welcome_popup.title
             assert community_params['intro'] == welcome_popup.intro
             welcome_popup.join().authenticate(user_one.password)
+            welcome_popup.share_address()
             assert driver.waitFor(lambda: not community_screen.left_panel.is_join_community_visible,
                                   configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Join community button not hidden'
 

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from datetime import datetime
 
 import allure
@@ -7,8 +6,6 @@ from allure_commons._allure import step
 
 import configs.testpath
 import constants
-import driver
-from constants import UserAccount
 from gui.main_window import MainWindow
 
 
@@ -125,86 +122,3 @@ def test_edit_community(main_screen: MainWindow, params):
         assert community_info.description == params['description']
         # TODO after https://github.com/status-im/status-desktop/issues/12967 will be fixed
         # assert '1' in community_info.members
-
-
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703510', 'Join community via owner invite')
-@pytest.mark.case(703510)
-@pytest.mark.parametrize('user_data_one, user_data_two', [
-    (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
-])
-def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
-    user_one: UserAccount = constants.user_account_one
-    user_two: UserAccount = constants.user_account_two
-    community_params = deepcopy(constants.community_params)
-    community_params['name'] = f'{datetime.now():%d%m%Y_%H%M%S}'
-    main_window = MainWindow()
-
-    with multiple_instance() as aut_one, multiple_instance() as aut_two:
-        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
-            for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
-                aut.attach()
-                main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
-                main_window.authorize_user(account)
-                main_window.hide()
-
-        with step(f'User {user_two.name}, get chat key'):
-            aut_two.attach()
-            main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
-            chat_key = profile_popup.chat_key
-            profile_popup.close()
-            main_window.hide()
-
-        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
-            aut_one.attach()
-            main_window.prepare()
-            settings = main_window.left_panel.open_settings()
-            messaging_settings = settings.left_panel.open_messaging_settings()
-            contacts_settings = messaging_settings.open_contacts_settings()
-            contact_request_popup = contacts_settings.open_contact_request_form()
-            contact_request_popup.send(chat_key, f'Hello {user_two.name}')
-            main_window.hide()
-
-        with step(f'User {user_two.name}, accept contact request from {user_one.name}'):
-            aut_two.attach()
-            main_window.prepare()
-            settings = main_window.left_panel.open_settings()
-            messaging_settings = settings.left_panel.open_messaging_settings()
-            contacts_settings = messaging_settings.open_contacts_settings()
-            contacts_settings.accept_contact_request(user_one.name)
-            main_window.hide()
-
-        with step(f'User {user_one.name}, create community and {user_two.name}'):
-            aut_one.attach()
-            main_window.prepare()
-            main_window.create_community(community_params)
-            main_window.left_panel.invite_people_in_community([user_two.name], 'Message', community_params['name'])
-            main_window.hide()
-
-        with step(f'User {user_two.name}, accept invitation from {user_one.name}'):
-            aut_two.attach()
-            main_window.prepare()
-            messages_view = main_window.left_panel.open_messages_screen()
-            chat = messages_view.left_panel.open_chat(user_one.name)
-            community_screen = chat.accept_community_invite(community_params['name'])
-
-        with step(f'User {user_two.name}, verify welcome community popup'):
-            welcome_popup = community_screen.left_panel.open_welcome_community_popup()
-            assert community_params['name'] in welcome_popup.title
-            assert community_params['intro'] == welcome_popup.intro
-            welcome_popup.join().authenticate(user_one.password)
-            welcome_popup.share_address()
-            assert driver.waitFor(lambda: not community_screen.left_panel.is_join_community_visible,
-                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Join community button not hidden'
-
-        with step(f'User {user_two.name}, see two members in community members list'):
-            assert user_one.name in community_screen.right_panel.members
-            assert driver.waitFor(lambda: '2' in community_screen.left_panel.members)
-            main_window.hide()
-
-        with step(f'User {user_one.name}, see two members in community members list'):
-            aut_one.attach()
-            main_window.prepare()
-            assert user_one.name in community_screen.right_panel.members
-            assert driver.waitFor(lambda: user_two.name in community_screen.right_panel.members)
-            assert '2' in community_screen.left_panel.members

--- a/tests/communities/test_communities_channels.py
+++ b/tests/communities/test_communities_channels.py
@@ -9,9 +9,10 @@ from gui.screens.community import CommunityScreen
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703049', 'Create community channel')
 @pytest.mark.case(703049)
-@pytest.mark.parametrize('channel_name, channel_description, channel_emoji', [('Channel', 'Description', 'sunglasses')])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
-def test_create_community_channel(main_screen: MainWindow, channel_name, channel_description, channel_emoji):
+@pytest.mark.parametrize('channel_name, channel_description, channel_emoji, channel_emoji_image, channel_color',
+                         [('Channel', 'Description', 'sunglasses', '😎', '#4360df')])
+def test_create_community_channel(main_screen: MainWindow, channel_name, channel_description, channel_emoji,
+                                  channel_emoji_image, channel_color):
     main_screen.create_community(constants.community_params)
     community_screen = main_screen.left_panel.select_community(constants.community_params['name'])
     community_screen.create_channel(channel_name, channel_description, channel_emoji)
@@ -20,17 +21,17 @@ def test_create_community_channel(main_screen: MainWindow, channel_name, channel
         community_screen.verify_channel(
             channel_name,
             channel_description,
-            'channel_icon_in_list.png',
-            'channel_icon_in_toolbar.png',
-            'channel_icon_in_chat.png'
+            channel_emoji_image,
+            channel_color
         )
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703050', 'Edit community channel')
 @pytest.mark.case(703050)
-@pytest.mark.parametrize('channel_name, channel_description, channel_emoji', [('Channel', 'Description', 'sunglasses')])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
-def test_edit_community_channel(main_screen, channel_name, channel_description, channel_emoji):
+@pytest.mark.parametrize('channel_name, channel_description, channel_emoji, channel_emoji_image, channel_color',
+                         [('Channel', 'Description', 'sunglasses', None, '#4360df')])
+def test_edit_community_channel(main_screen, channel_name, channel_description, channel_emoji, channel_emoji_image,
+                                channel_color):
     main_screen.create_community(constants.community_params)
     community_screen = CommunityScreen()
 
@@ -38,26 +39,26 @@ def test_edit_community_channel(main_screen, channel_name, channel_description, 
         community_screen.verify_channel(
             'general',
             'General channel for the community',
-            'general_channel_icon_in_list.png',
-            'general_channel_icon_in_toolbar.png',
-            'general_channel_icon_in_chat.png'
+            None,
+            channel_color
         )
 
     community_screen.edit_channel('general', channel_name, channel_description, channel_emoji)
 
-    with step('Verify General channel'):
-        community_screen.verify_channel(
-            channel_name,
-            channel_description,
-            'channel_icon_in_list.png',
-            'channel_icon_in_toolbar.png',
-            'channel_icon_in_chat.png'
-        )
+    with step('Channel is correct in channels list'):
+        channel = community_screen.left_panel.get_channel_parameters(channel_name)
+        assert channel.name == channel_name
+        assert channel.selected
+
+    with step('Channel is correct in community toolbar'):
+        assert community_screen.tool_bar.channel_name == channel_name
+        assert community_screen.tool_bar.channel_description == channel_description
+        assert community_screen.tool_bar.channel_emoji == '😎 '
+        assert community_screen.tool_bar.channel_color == channel_color
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703051', 'Delete community channel')
 @pytest.mark.case(703051)
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
 def test_delete_community_channel(main_screen):
     main_screen.create_community(constants.community_params)
 

--- a/tests/communities/test_join_community.py
+++ b/tests/communities/test_join_community.py
@@ -1,0 +1,95 @@
+from copy import deepcopy
+from datetime import datetime
+
+import allure
+import pytest
+from allure_commons._allure import step
+
+import configs.testpath
+import constants
+import driver
+from constants import UserAccount
+from gui.main_window import MainWindow
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703510', 'Join community via owner invite')
+@pytest.mark.case(703510)
+@pytest.mark.parametrize('user_data_one, user_data_two', [
+    (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
+])
+def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
+    user_one: UserAccount = constants.user_account_one
+    user_two: UserAccount = constants.user_account_two
+    community_params = deepcopy(constants.community_params)
+    community_params['name'] = f'{datetime.now():%d%m%Y_%H%M%S}'
+    main_window = MainWindow()
+
+    with multiple_instance() as aut_one, multiple_instance() as aut_two:
+        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
+            for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
+                aut.attach()
+                main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
+                main_window.authorize_user(account)
+                main_window.hide()
+
+        with step(f'User {user_two.name}, get chat key'):
+            aut_two.attach()
+            main_window.prepare()
+            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            chat_key = profile_popup.chat_key
+            profile_popup.close()
+            main_window.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contact_request_popup = contacts_settings.open_contact_request_form()
+            contact_request_popup.send(chat_key, f'Hello {user_two.name}')
+            main_window.hide()
+
+        with step(f'User {user_two.name}, accept contact request from {user_one.name}'):
+            aut_two.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contacts_settings.accept_contact_request(user_one.name)
+            main_window.hide()
+
+        with step(f'User {user_one.name}, create community and {user_two.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            main_window.create_community(community_params)
+            main_window.left_panel.invite_people_in_community([user_two.name], 'Message', community_params['name'])
+            main_window.hide()
+
+        with step(f'User {user_two.name}, accept invitation from {user_one.name}'):
+            aut_two.attach()
+            main_window.prepare()
+            messages_view = main_window.left_panel.open_messages_screen()
+            chat = messages_view.left_panel.open_chat(user_one.name)
+            community_screen = chat.accept_community_invite(community_params['name'])
+
+        with step(f'User {user_two.name}, verify welcome community popup'):
+            welcome_popup = community_screen.left_panel.open_welcome_community_popup()
+            assert community_params['name'] in welcome_popup.title
+            assert community_params['intro'] == welcome_popup.intro
+            welcome_popup.join().authenticate(user_one.password)
+            welcome_popup.share_address()
+            assert driver.waitFor(lambda: not community_screen.left_panel.is_join_community_visible,
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Join community button not hidden'
+
+        with step(f'User {user_two.name}, see two members in community members list'):
+            assert user_one.name in community_screen.right_panel.members
+            assert driver.waitFor(lambda: '2' in community_screen.left_panel.members)
+            main_window.hide()
+
+        with step(f'User {user_one.name}, see two members in community members list'):
+            aut_one.attach()
+            main_window.prepare()
+            assert user_one.name in community_screen.right_panel.members
+            assert driver.waitFor(lambda: user_two.name in community_screen.right_panel.members)
+            assert '2' in community_screen.left_panel.members


### PR DESCRIPTION
* Fixed join community test (object names changed in the app, also there were some changes in scenarios, so I updated test)
* Got rid of image comparison, in some tests I had to remove it at all (because we don't use screenshots anymore, but it was not possible to replace it with other verifications), in others - just replaced with another verifications (color, emoji etc.)
* Removed skip marks from all communities tests
* Commented one verification (will be enabled after bug is fixed)
* Changed method of getting members and name, because it didn't work anymore in old method

Test run on CI: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1200/allure/
