### PR TITLE
chore: removed wait until appears from open_wallet method

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -126,12 +126,12 @@ class LeftPanel(QObject):
     def open_wallet(self, attempts: int = 2) -> WalletScreen:
         self._wallet_button.click()
         try:
-            return WalletScreen().wait_until_appears()
-        except AssertionError as err:
+            return WalletScreen()
+        except Exception as ex:
             if attempts:
                 return self.open_wallet(attempts - 1)
             else:
-                raise err
+                raise ex
 
 
 class MainWindow(Window):

--- a/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -84,7 +84,6 @@ def test_settings_include_in_total_balance(main_screen: MainWindow, name, watche
         main_screen.left_panel.open_wallet().left_panel.hide_include_in_total_balance_from_context_menu(name)
 
     with step('Check the balance is back to 0 again'):
-        main_screen.left_panel.open_wallet()
         assert driver.waitFor(
             lambda: float(wallet_main_screen.left_panel.get_total_balance_value().replace("\xa0", "")
                           .replace(",", "")) == 0, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), \


### PR DESCRIPTION
Let's try to survive without this `wait_until_appears` because it is unstable

**CI run:** https://ci.status.im/job/status-desktop/job/qa-automation/job/prs/job/PR-373/1/

**Allure:** https://ci.status.im/job/status-desktop/job/qa-automation/job/prs/job/PR-373/1/allure/

<img width="1840" alt="Screenshot 2023-12-11 at 10 53 11" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/ccfbd58b-2118-46b2-ab0a-608594ab2e08">
