### PR TITLE
chore: skip balance test and ENS name test because of cryptocompare API limit and coinGecko issue

### DIFF
--- a/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -20,6 +20,7 @@ from gui.screens.settings_wallet import WalletSettingsView
     pytest.param('0x7f1502605A2f2Cc01f9f4E7dd55e549954A8cD0C', ''.join(random.choices(string.ascii_letters +
                                                                                       string.digits, k=20)))
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12987")
 def test_settings_include_in_total_balance(main_screen: MainWindow, name, watched_address):
     with (step('Open wallet on main screen and check the total balance for new account is 0')):
         wallet_main_screen = main_screen.left_panel.open_wallet()

--- a/tests/settings/test_ens_name_purchase.py
+++ b/tests/settings/test_ens_name_purchase.py
@@ -31,6 +31,7 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.case(704597)
 @pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
 @pytest.mark.parametrize('ens_name', [pytest.param(constants.user.ens_user_name)])
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/12988')
 def test_ens_name_purchase(keys_screen, main_window, user_account, ens_name):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()


### PR DESCRIPTION
1. I logged https://github.com/status-im/status-desktop/issues/12987 which has some details about cryptocompare

The problem is that we sometimes do not fetch prices and therefore do not show balances on the left panel

![image](https://github.com/status-im/desktop-qa-automation/assets/82375995/52dd6599-4e73-4346-af01-dce02182e700)

2. i also logged https://github.com/status-im/status-desktop/issues/12988 about error with buying ENS
![image](https://github.com/status-im/desktop-qa-automation/assets/82375995/e45e708d-b9ad-47a3-a89b-589de2fae2ad)


