### PR TITLE
Chore/test mode: stabilise tests to allow them pass in STATUS_RUNTIME_TEST_MODE = True

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
     TESTRAIL_PROJECT_ID = 17
 
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
-    STATUS_RUNTIME_TEST_MODE = 'True'
+    /* STATUS_RUNTIME_TEST_MODE = 'True' */
   }
 
   stages {

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
     TESTRAIL_PROJECT_ID = 17
 
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
-    /* STATUS_RUNTIME_TEST_MODE = '1' */
+    STATUS_RUNTIME_TEST_MODE = 'True'
   }
 
   stages {

--- a/gui/components/delete_popup.py
+++ b/gui/components/delete_popup.py
@@ -10,10 +10,17 @@ class DeletePopup(BasePopup):
         super().__init__()
         self._delete_button = Button('delete_StatusButton')
 
-    @allure.step("Delete entity")
-    def delete(self):
-        self._delete_button.click()
-        self.wait_until_hidden()
+    @allure.step("Delete channel")
+    def delete(self, attempts: int = 2):
+        try:
+            self._delete_button.click()
+        except Exception as ex:
+            if attempts:
+                self.delete(attempts-1)
+            else:
+                raise ex
+
+
 
 
 class DeleteCategoryPopup(DeletePopup):

--- a/gui/components/online_identifier.py
+++ b/gui/components/online_identifier.py
@@ -11,16 +11,21 @@ from gui.elements.object import QObject
 from gui.elements.text_label import TextLabel
 
 
-class UserCanvas(QObject):
+class OnlineIdentifier(QObject):
 
     def __init__(self):
-        super(UserCanvas, self).__init__('o_StatusListView')
+        super(OnlineIdentifier, self).__init__('o_StatusListView')
         self._always_active_button = Button('userContextmenu_AlwaysActiveButton')
         self._inactive_button = Button('userContextmenu_InActiveButton')
         self._automatic_button = Button('userContextmenu_AutomaticButton')
         self._view_my_profile_button = Button('userContextMenu_ViewMyProfileAction')
         self._user_name_text_label = TextLabel('userLabel_StyledText')
         self._profile_image = QObject('o_StatusIdenticonRing')
+
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        driver.waitFor(lambda: self._view_my_profile_button.is_visible, timeout_msec)
+        return self
 
     @property
     @allure.step('Get profile image')
@@ -31,12 +36,6 @@ class UserCanvas(QObject):
     @allure.step('Get user name')
     def user_name(self) -> str:
         return self._user_name_text_label.text
-
-    @allure.step('Wait until appears {0}')
-    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
-        super(UserCanvas, self).wait_until_appears(timeout_msec)
-        time.sleep(1)
-        return self
 
     @allure.step('Set user state online')
     def set_user_state_online(self):

--- a/gui/components/user_canvas.py
+++ b/gui/components/user_canvas.py
@@ -53,10 +53,17 @@ class UserCanvas(QObject):
         self._automatic_button.click()
         self.wait_until_hidden()
 
-    @allure.step('Open Profile popup')
-    def open_profile_popup(self) -> ProfilePopup:
+    @allure.step('Open Profile popup from online identifier')
+    def open_profile_popup_from_online_identifier(self, attempts: int =2) -> ProfilePopup:
         self._view_my_profile_button.click()
-        return ProfilePopup().wait_until_appears()
+        time.sleep(0.5)
+        try:
+            return ProfilePopup()
+        except Exception as ex:
+            if attempts:
+                self.open_profile_popup_from_online_identifier(attempts - 1)
+            else:
+                raise ex
 
     @allure.step('Verify: User image contains text')
     def is_user_image_contains(self, text: str):

--- a/gui/components/wallet/popup_delete_account_from_settings.py
+++ b/gui/components/wallet/popup_delete_account_from_settings.py
@@ -1,21 +1,27 @@
 import allure
 
 import configs
+from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
+from gui.elements.check_box import CheckBox
 from gui.elements.text_label import TextLabel
 from gui.screens.settings_wallet import *
 from gui.elements.object import QObject
 
 
-class RemoveAccountConfirmationSettings(QObject):
+class RemoveAccountConfirmationSettings(BasePopup):
 
     def __init__(self):
-        super(RemoveAccountConfirmationSettings, self).__init__('removeConfirmationTextTitle')
+        super(RemoveAccountConfirmationSettings, self).__init__()
         self._remove_confirmation_close_button = Button('removeConfirmationCrossCloseButton')
         self._remove_confirmation_title_text = TextLabel('removeConfirmationTextTitle')
         self._remove_confirmation_body_text = TextLabel('removeConfirmationTextBody')
         self._remove_confirmation_remove_account_button = Button('removeConfirmationRemoveButton')
+        self._remove_confirmation_agreement_checkbox = CheckBox('removeConfirmationAgreementCheckBox')
+        self._remove_confirmation_confirm_button = Button('removeConfirmationConfirmButton')
 
     @allure.step('Click Remove account button')
-    def click_remove_account_button(self):
-        self._remove_confirmation_remove_account_button.click()
+    def remove_account_with_confirmation(self):
+        self._remove_confirmation_agreement_checkbox.set(True)
+        self._remove_confirmation_confirm_button.click()
+

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -14,7 +14,7 @@ from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
 from gui.components.splash_screen import SplashScreen
 from gui.components.toast_message import ToastMessage
-from gui.components.user_canvas import UserCanvas
+from gui.components.online_identifier import OnlineIdentifier
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.window import Window
@@ -65,21 +65,21 @@ class LeftPanel(QObject):
         self._messages_button.click()
         return MessagesScreen().wait_until_appears()
 
-    @allure.step('Open user online identifier')
-    def open_user_online_identifier(self, attempts: int = 2) -> UserCanvas:
+    @allure.step('Open online identifier')
+    def open_online_identifier(self, attempts: int = 2) -> OnlineIdentifier:
         time.sleep(0.5)
         self._profile_button.click()
         try:
-            return UserCanvas()
+            return OnlineIdentifier().wait_until_appears()
         except Exception as ex:
             if attempts:
-                self.open_user_online_identifier(attempts - 1)
+                self.open_online_identifier(attempts - 1)
             else:
                 raise ex
 
     @allure.step('Set user to online')
     def set_user_to_online(self):
-        self.open_user_online_identifier().set_user_state_online()
+        self.open_online_identifier().set_user_state_online()
 
     @allure.step('Verify: User is online')
     def user_is_online(self) -> bool:
@@ -87,7 +87,7 @@ class LeftPanel(QObject):
 
     @allure.step('Set user to offline')
     def set_user_to_offline(self):
-        self.open_user_online_identifier().set_user_state_offline()
+        self.open_online_identifier().set_user_state_offline()
 
     @allure.step('Verify: User is offline')
     def user_is_offline(self):
@@ -95,7 +95,7 @@ class LeftPanel(QObject):
 
     @allure.step('Set user to automatic')
     def set_user_to_automatic(self):
-        self.open_user_online_identifier().set_user_automatic_state()
+        self.open_online_identifier().set_user_automatic_state()
 
     @allure.step('Verify: User is set to automatic')
     def user_is_set_to_automatic(self):
@@ -130,9 +130,16 @@ class LeftPanel(QObject):
         InviteContactsPopup().wait_until_appears().invite(contacts, message)
 
     @allure.step('Open settings')
-    def open_settings(self) -> SettingsScreen:
+    def open_settings(self, attempts: int = 2) -> SettingsScreen:
         self._settings_button.click()
-        return SettingsScreen().wait_until_appears()
+        time.sleep(0.5)
+        try:
+            return SettingsScreen()
+        except Exception as ex:
+            if attempts:
+                self.open_settings(attempts - 1)
+            else:
+                raise ex
 
     @allure.step('Open Wallet section')
     def open_wallet(self, attempts: int = 2) -> WalletScreen:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -48,7 +48,12 @@ class LeftPanel(QObject):
         community_names = []
         for obj in driver.findAllObjects(self._community_template_button.real_name):
             community_names.append(obj.name)
-        return community_names
+
+        if len(community_names) == 0:
+            raise LookupError(
+                'Communities not found')
+        else:
+            return community_names
 
     @property
     @allure.step('Get user badge color')
@@ -60,14 +65,21 @@ class LeftPanel(QObject):
         self._messages_button.click()
         return MessagesScreen().wait_until_appears()
 
-    @allure.step('Open user canvas')
-    def open_user_canvas(self) -> UserCanvas:
+    @allure.step('Open user online identifier')
+    def open_user_online_identifier(self, attempts: int = 2) -> UserCanvas:
+        time.sleep(0.5)
         self._profile_button.click()
-        return UserCanvas().wait_until_appears()
+        try:
+            return UserCanvas()
+        except Exception as ex:
+            if attempts:
+                self.open_user_online_identifier(attempts - 1)
+            else:
+                raise ex
 
     @allure.step('Set user to online')
     def set_user_to_online(self):
-        self.open_user_canvas().set_user_state_online()
+        self.open_user_online_identifier().set_user_state_online()
 
     @allure.step('Verify: User is online')
     def user_is_online(self) -> bool:
@@ -75,7 +87,7 @@ class LeftPanel(QObject):
 
     @allure.step('Set user to offline')
     def set_user_to_offline(self):
-        self.open_user_canvas().set_user_state_offline()
+        self.open_user_online_identifier().set_user_state_offline()
 
     @allure.step('Verify: User is offline')
     def user_is_offline(self):
@@ -83,7 +95,7 @@ class LeftPanel(QObject):
 
     @allure.step('Set user to automatic')
     def set_user_to_automatic(self):
-        self.open_user_canvas().set_user_automatic_state()
+        self.open_user_online_identifier().set_user_automatic_state()
 
     @allure.step('Verify: User is set to automatic')
     def user_is_set_to_automatic(self):

--- a/gui/objects_map/component_names.py
+++ b/gui/objects_map/component_names.py
@@ -281,6 +281,8 @@ removeConfirmationCrossCloseButton = {"container": statusDesktop_mainWindow_over
 removeConfirmationTextTitle = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerTitle", "type": "StatusBaseText", "visible": True}
 removeConfirmationTextBody = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 removeConfirmationRemoveButton = {"container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("confirm*"), "type": "StatusButton"}
+removeConfirmationAgreementCheckBox = {"container": statusDesktop_mainWindow_overlay, "objectName": "RemoveAccountPopup-HavePenPaper", "type": "StatusCheckBox"}
+removeConfirmationConfirmButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "RemoveAccountPopup-ConfirmButton", "type": "StatusButton"}
 
 # Testnet mode popup
 turn_on_testnet_mode_StatusButton = {"container": statusDesktop_mainWindow_overlay, "id": "acceptBtn", "text": "Turn on testnet mode", "type": "StatusButton", "unnamed": 1, "visible": True}

--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -201,6 +201,7 @@ class LeftPanel(QObject):
     @property
     @allure.step('Get channels')
     def channels(self) -> typing.List[UserChannel]:
+        time.sleep(0.5)
         channels_list = []
         for obj in driver.findAllObjects(self._channel_list_item.real_name):
             container = driver.objectMap.realName(obj)

--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -34,7 +34,7 @@ class CommunityScreen(QObject):
     def create_channel(self, name: str, description: str, emoji: str = None):
         self.left_panel.open_create_channel_popup().create(name, description, emoji)
 
-    @allure.step('Create channel')
+    @allure.step('Edit channel')
     def edit_channel(self, channel, name: str, description: str, emoji: str = None):
         self.left_panel.select_channel(channel)
         self.tool_bar.open_edit_channel_popup().edit(name, description, emoji)
@@ -218,9 +218,9 @@ class LeftPanel(QObject):
 
     @allure.step('Get channel params')
     def get_channel_parameters(self, name) -> UserChannel:
-        for channal in self.channels:
-            if channal.name == name:
-                return channal
+        for channel in self.channels:
+            if channel.name == name:
+                return channel
         raise LookupError(f'Channel not found in {self.channels}')
 
     @allure.step('Open community settings')
@@ -243,10 +243,16 @@ class LeftPanel(QObject):
         raise LookupError('Channel not found')
 
     @allure.step('Open create category popup')
-    def open_create_category_popup(self) -> NewCategoryPopup:
+    def open_create_category_popup(self, attempts: int = 2) -> NewCategoryPopup:
         self._channel_or_category_button.click()
-        self._create_category_menu_item.click()
-        return NewCategoryPopup().wait_until_appears()
+        try:
+            self._create_category_menu_item.click()
+            return NewCategoryPopup().wait_until_appears()
+        except Exception as ex:
+            if attempts:
+                self.open_create_category_popup(attempts-1)
+            else:
+                raise ex
 
     @allure.step('Open join community popup')
     def open_welcome_community_popup(self):

--- a/gui/screens/community_settings.py
+++ b/gui/screens/community_settings.py
@@ -1,3 +1,4 @@
+import time
 import typing
 
 import allure
@@ -86,10 +87,16 @@ class OverviewView(QObject):
         return self._description_text_label.text
 
     @allure.step('Open edit community view')
-    def open_edit_community_view(self) -> 'EditCommunityView':
+    def open_edit_community_view(self, attempts: int = 2) -> 'EditCommunityView':
+        time.sleep(0.5)
         self._edit_button.click()
-        return EditCommunityView().wait_until_appears()
-
+        try:
+            return EditCommunityView()
+        except Exception as ex:
+            if attempts:
+                self.open_edit_community_view(attempts-1)
+            else:
+                raise ex
 
 class EditCommunityView(QObject):
 

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -50,9 +50,16 @@ class LeftPanel(QObject):
                 raise ex
 
     @allure.step('Open wallet settings')
-    def open_wallet_settings(self) -> WalletSettingsView:
+    def open_wallet_settings(self, attempts: int = 2) -> WalletSettingsView:
         self._open_settings('4-AppMenuItem')
-        return WalletSettingsView().wait_until_appears()
+        time.sleep(0.5)
+        try:
+            return WalletSettingsView()
+        except Exception as ex:
+            if attempts:
+                self.open_wallet_settings(attempts-1)
+            else:
+                raise ex
 
     @allure.step('Open profile settings')
     def open_profile_settings(self) -> ProfileSettingsView:

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -39,9 +39,15 @@ class LeftPanel(QObject):
         return MessagingSettingsView()
 
     @allure.step('Open communities settings')
-    def open_communities_settings(self) -> 'CommunitiesSettingsView':
+    def open_communities_settings(self, attempts: int = 2) -> 'CommunitiesSettingsView':
         self._open_settings('12-AppMenuItem')
-        return CommunitiesSettingsView()
+        try:
+            return CommunitiesSettingsView()
+        except Exception as ex:
+            if attempts:
+                self.open_communities_settings(attempts-1)
+            else:
+                raise ex
 
     @allure.step('Open wallet settings')
     def open_wallet_settings(self) -> WalletSettingsView:

--- a/gui/screens/settings_communities.py
+++ b/gui/screens/settings_communities.py
@@ -29,6 +29,7 @@ class CommunitiesSettingsView(QObject):
     @property
     @allure.step('Get communities')
     def communities(self) -> typing.List[UserCommunityInfo]:
+        time.sleep(0.5)
         _communities = []
         for obj in driver.findAllObjects(self._community_item.real_name):
             container = driver.objectMap.realName(obj)

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -63,8 +63,14 @@ class WalletSettingsView(QObject):
 
     @allure.step('Get keypair names')
     def get_keypairs_names(self):
-        return [str(getattr(item, 'title', '')) for item in
-                driver.findAllObjects(self._wallet_settings_keypair_item.real_name)]
+        keypair_names = []
+        for item in driver.findAllObjects(self._wallet_settings_keypair_item.real_name):
+            keypair_names.append(str(getattr(item, 'title', '')))
+        if keypair_names == 0:
+            raise LookupError(
+                'No keypairs found on the wallet settings screen')
+        else:
+            return keypair_names
 
     @allure.step('Open account view in wallet settings by name')
     def open_account_in_settings(self, name):
@@ -252,7 +258,7 @@ class EditNetworkSettings(WalletSettingsView):
         self._test_network_tab.click()
 
     @allure.step('Click Revert to default button and redirect to Networks screen')
-    def click_revert_to_default_and_go_to_networks_main_screen(self, attempts: int=2):
+    def click_revert_to_default_and_go_to_networks_main_screen(self, attempts: int = 2):
         self._network_edit_scroll.vertical_down_to(self._network_revert_to_default)
         self._network_revert_to_default.click()
         try:

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -66,7 +66,7 @@ class WalletSettingsView(QObject):
         keypair_names = []
         for item in driver.findAllObjects(self._wallet_settings_keypair_item.real_name):
             keypair_names.append(str(getattr(item, 'title', '')))
-        if keypair_names == 0:
+        if len(keypair_names) == 0:
             raise LookupError(
                 'No keypairs found on the wallet settings screen')
         else:

--- a/tests/communities/test_communities_channels.py
+++ b/tests/communities/test_communities_channels.py
@@ -70,5 +70,5 @@ def test_delete_community_channel(main_screen):
     with step('Delete channel'):
         community_screen.delete_channel('general')
 
-    with step('Verify channel is not exists'):
-        assert not community_screen.left_panel.channels
+    with step('Verify channel list is empty'):
+        assert len(community_screen.left_panel.channels) == 0

--- a/tests/communities/test_communities_channels.py
+++ b/tests/communities/test_communities_channels.py
@@ -32,10 +32,11 @@ def test_create_community_channel(main_screen: MainWindow, channel_name, channel
                          [('Channel', 'Description', 'sunglasses', None, '#4360df')])
 def test_edit_community_channel(main_screen, channel_name, channel_description, channel_emoji, channel_emoji_image,
                                 channel_color):
-    main_screen.create_community(constants.community_params)
-    community_screen = CommunityScreen()
+    with step('Create simple community'):
+        main_screen.create_community(constants.community_params)
+        community_screen = main_screen.left_panel.select_community(constants.community_params['name'])
 
-    with step('Verify General channel'):
+    with step('Verify General channel is present for recently created community'):
         community_screen.verify_channel(
             'general',
             'General channel for the community',
@@ -43,14 +44,15 @@ def test_edit_community_channel(main_screen, channel_name, channel_description, 
             channel_color
         )
 
-    community_screen.edit_channel('general', channel_name, channel_description, channel_emoji)
+    with step('Edit general channel'):
+        community_screen.edit_channel('general', channel_name, channel_description, channel_emoji)
 
-    with step('Channel is correct in channels list'):
+    with step('Verify edited channel details are correct in channels list'):
         channel = community_screen.left_panel.get_channel_parameters(channel_name)
         assert channel.name == channel_name
         assert channel.selected
 
-    with step('Channel is correct in community toolbar'):
+    with step('Verify edited channel details are correct in community toolbar'):
         assert community_screen.tool_bar.channel_name == channel_name
         assert community_screen.tool_bar.channel_description == channel_description
         assert community_screen.tool_bar.channel_emoji == '😎 '
@@ -60,10 +62,13 @@ def test_edit_community_channel(main_screen, channel_name, channel_description, 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703051', 'Delete community channel')
 @pytest.mark.case(703051)
 def test_delete_community_channel(main_screen):
-    main_screen.create_community(constants.community_params)
+
+    with step('Create simple community'):
+        main_screen.create_community(constants.community_params)
+        community_screen = main_screen.left_panel.select_community(constants.community_params['name'])
 
     with step('Delete channel'):
-        CommunityScreen().delete_channel('general')
+        community_screen.delete_channel('general')
 
     with step('Verify channel is not exists'):
-        assert not CommunityScreen().left_panel.channels
+        assert not community_screen.left_panel.channels

--- a/tests/communities/test_join_community.py
+++ b/tests/communities/test_join_community.py
@@ -35,7 +35,7 @@ def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/communities/test_join_community.py
+++ b/tests/communities/test_join_community.py
@@ -35,7 +35,7 @@ def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -36,7 +36,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()
@@ -63,7 +63,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
         with step(f'User {user_three.name}, get chat key'):
             aut_three.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -36,7 +36,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()
@@ -63,7 +63,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
         with step(f'User {user_three.name}, get chat key'):
             aut_three.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -84,7 +84,7 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
 
     with step('Open User Canvas and verify user info'):
 
-        user_canvas = main_window.left_panel.open_user_online_identifier()
+        user_canvas = main_window.left_panel.open_online_identifier()
         assert user_canvas.user_name == user_name
         # TODO: temp removing tesseract usage because it is not stable
     # if user_image is None:

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -84,7 +84,7 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
 
     with step('Open User Canvas and verify user info'):
 
-        user_canvas = main_window.left_panel.open_user_canvas()
+        user_canvas = main_window.left_panel.open_user_online_identifier()
         assert user_canvas.user_name == user_name
         # TODO: temp removing tesseract usage because it is not stable
     # if user_image is None:
@@ -95,7 +95,7 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
 
     with step('Open Profile popup and verify user info'):
 
-        profile_popup = user_canvas.open_profile_popup()
+        profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_name
         assert profile_popup.chat_key == chat_key
         assert profile_popup.emoji_hash.compare(emoji_hash.view, threshold=0.9)

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -58,7 +58,7 @@ def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, au
             f"Recovered account should have address {user_account.status_address}, but has {address}"
 
     with step('Verify that the user logged in via seed phrase correctly'):
-        user_canvas = main_window.left_panel.open_user_online_identifier()
+        user_canvas = main_window.left_panel.open_online_identifier()
         profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
         

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -58,7 +58,7 @@ def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, au
             f"Recovered account should have address {user_account.status_address}, but has {address}"
 
     with step('Verify that the user logged in via seed phrase correctly'):
-        user_canvas = main_window.left_panel.open_user_canvas()
-        profile_popup = user_canvas.open_profile_popup()
+        user_canvas = main_window.left_panel.open_user_online_identifier()
+        profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
         

--- a/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -50,8 +50,8 @@ def test_login_with_wrong_password(aut: AUT, keys_screen, main_window, error: st
             BetaConsentPopup().confirm()
 
     with step('Verify that the user logged in correctly'):
-        user_canvas = main_window.left_panel.open_user_canvas()
-        profile_popup = user_canvas.open_profile_popup()
+        user_canvas = main_window.left_panel.open_user_online_identifier()
+        profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_one.name
 
     with step('Restart application and input wrong password'):

--- a/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -50,7 +50,7 @@ def test_login_with_wrong_password(aut: AUT, keys_screen, main_window, error: st
             BetaConsentPopup().confirm()
 
     with step('Verify that the user logged in correctly'):
-        user_canvas = main_window.left_panel.open_user_online_identifier()
+        user_canvas = main_window.left_panel.open_online_identifier()
         profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_one.name
 

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -86,7 +86,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
                 BetaConsentPopup().confirm()
 
         with step('Verify user details are the same with user in first instance'):
-            user_canvas = main_window.left_panel.open_user_canvas()
+            user_canvas = main_window.left_panel.open_user_online_identifier()
             user_canvas_name = user_canvas.user_name
             assert user_canvas_name == user.name
             # TODO: temp removing tesseract usage because it is not stable

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -86,7 +86,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
                 BetaConsentPopup().confirm()
 
         with step('Verify user details are the same with user in first instance'):
-            user_canvas = main_window.left_panel.open_user_online_identifier()
+            user_canvas = main_window.left_panel.open_online_identifier()
             user_canvas_name = user_canvas.user_name
             assert user_canvas_name == user.name
             # TODO: temp removing tesseract usage because it is not stable

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -16,7 +16,7 @@ pytestmark = allure.suite("Settings")
 @pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
 def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
     with step('Open own profile popup and check name of user is correct'):
-        profile = main_screen.left_panel.open_user_online_identifier()
+        profile = main_screen.left_panel.open_online_identifier()
         profile_popup = profile.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
 
@@ -24,7 +24,7 @@ def test_change_own_display_name(main_screen: MainWindow, user_account, new_name
         profile_popup.edit_profile().set_name(new_name)
 
     with step('Open own profile popup and check name of user is correct'):
-        assert main_screen.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier().user_name == new_name
+        assert main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name == new_name
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703002', 'Switch state to offline')

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -16,15 +16,15 @@ pytestmark = allure.suite("Settings")
 @pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
 def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
     with step('Open own profile popup and check name of user is correct'):
-        profile = main_screen.left_panel.open_user_canvas()
-        profile_popup = profile.open_profile_popup()
+        profile = main_screen.left_panel.open_user_online_identifier()
+        profile_popup = profile.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
 
     with step('Go to edit profile settings and change the name of the user'):
         profile_popup.edit_profile().set_name(new_name)
 
     with step('Open own profile popup and check name of user is correct'):
-        assert main_screen.left_panel.open_user_canvas().open_profile_popup().user_name == new_name
+        assert main_screen.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier().user_name == new_name
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703002', 'Switch state to offline')

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
@@ -31,7 +31,7 @@ def test_messaging_settings_accepting_request(multiple_instance, user_data_one, 
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
@@ -31,7 +31,7 @@ def test_messaging_settings_accepting_request(multiple_instance, user_data_one, 
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
+            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()
@@ -63,13 +63,12 @@ def test_messaging_settings_accepting_request(multiple_instance, user_data_one, 
             assert user_one.name == contacts_settings.contact_items[0].contact
             assert len(contacts_settings.contact_items) == 1
 
-        # TODO: https://github.com/status-im/desktop-qa-automation/issues/346
-        # with step('Verify toast message about new contact request received'):
-        #     assert len(ToastMessage().get_toast_messages) == 1, \
-        #         f"Multiple toast messages appeared"
-        #     message = ToastMessage().get_toast_messages[0]
-        #     assert message == Messaging.NEW_CONTACT_REQUEST.value, \
-        #         f"Toast message is incorrect, current message is {message}"
+        with step('Verify toast message about new contact request received'):
+            assert len(ToastMessage().get_toast_messages) == 1, \
+                f"Multiple toast messages appeared"
+            message = ToastMessage().get_toast_messages[0]
+            assert message == Messaging.NEW_CONTACT_REQUEST.value, \
+                f"Toast message is incorrect, current message is {message}"
 
         with step(f'User {user_two.name}, accept contact request from {user_one.name}'):
             contacts_settings.accept_contact_request(user_one.name)
@@ -90,65 +89,3 @@ def test_messaging_settings_accepting_request(multiple_instance, user_data_one, 
             assert contacts_settings.contacts_list_title == 'Contacts'
             assert user_two.name == contacts_settings.contact_items[0].contact
             assert len(contacts_settings.contact_items) == 1
-
-
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704610', 'Reject a contact request with a chat key')
-@pytest.mark.case(704610)
-@pytest.mark.parametrize('user_data_one, user_data_two', [
-    (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
-])
-def test_messaging_settings_rejecting_request(multiple_instance, user_data_one, user_data_two):
-    user_one: UserAccount = constants.user_account_one
-    user_two: UserAccount = constants.user_account_two
-    main_window = MainWindow()
-
-    with multiple_instance() as aut_one, multiple_instance() as aut_two:
-        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
-            for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
-                aut.attach()
-                main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
-                main_window.authorize_user(account)
-                main_window.hide()
-
-        with step(f'User {user_two.name}, get chat key'):
-            aut_two.attach()
-            main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_canvas().open_profile_popup()
-            chat_key = profile_popup.chat_key
-            profile_popup.close()
-            main_window.hide()
-
-        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
-            aut_one.attach()
-            main_window.prepare()
-            settings = main_window.left_panel.open_settings()
-            messaging_settings = settings.left_panel.open_messaging_settings()
-            contacts_settings = messaging_settings.open_contacts_settings()
-            contact_request_popup = contacts_settings.open_contact_request_form()
-            contact_request_popup.send(chat_key, f'Hello {user_two.name}')
-
-            main_window.hide()
-
-        with step(f'Verify that contact request from user {user_two.name} was received and reject contact request'):
-            aut_two.attach()
-            main_window.prepare()
-            settings = main_window.left_panel.open_settings()
-            messaging_settings = settings.left_panel.open_messaging_settings()
-            contacts_settings = messaging_settings.open_contacts_settings()
-            contacts_settings.open_pending_requests()
-            contacts_settings.reject_contact_request(user_one.name)
-
-        with step(f'Verify that contacts list of {user_two.name} is empty in messaging settings'):
-            contacts_settings = main_window.left_panel.open_settings().left_panel.open_messaging_settings().open_contacts_settings()
-            contacts_settings.open_contacts()
-            assert contacts_settings.no_friends_item_text == Messaging.NO_FRIENDS_ITEM.value
-            assert contacts_settings.is_invite_friends_button_visible
-            main_window.hide()
-
-        with step(f'Verify that contacts list of {user_one.name} is empty in messaging settings'):
-            aut_one.attach()
-            main_window.prepare()
-            contacts_settings = main_window.left_panel.open_settings().left_panel.open_messaging_settings().open_contacts_settings()
-            contacts_settings.open_contacts()
-            assert contacts_settings.no_friends_item_text == Messaging.NO_FRIENDS_ITEM.value
-            assert contacts_settings.is_invite_friends_button_visible

--- a/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
@@ -32,7 +32,7 @@ def test_messaging_settings_identity_verification(multiple_instance, user_data_o
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
@@ -30,7 +30,8 @@ def test_messaging_settings_rejecting_request(multiple_instance, user_data_one, 
         with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_window.prepare()
-            profile_popup = main_window.left_panel.open_user_online_identifier().open_profile_popup_from_online_identifier()
+            online_identifier = main_window.left_panel.open_online_identifier()
+            profile_popup = online_identifier.open_profile_popup_from_online_identifier()
             chat_key = profile_popup.chat_key
             profile_popup.close()
             main_window.hide()

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -24,6 +24,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         main_screen.authorize_user(user_account_changed_password)
 
     with step('Verify that the user logged in correctly'):
-        user_canvas = main_screen.left_panel.open_user_online_identifier()
+        user_canvas = main_screen.left_panel.open_online_identifier()
         profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -24,6 +24,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         main_screen.authorize_user(user_account_changed_password)
 
     with step('Verify that the user logged in correctly'):
-        user_canvas = main_screen.left_panel.open_user_canvas()
-        profile_popup = user_canvas.open_profile_popup()
+        user_canvas = main_screen.left_panel.open_user_online_identifier()
+        profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -57,7 +57,7 @@ def test_delete_generated_account_from_wallet_settings(
 
     with step('Delete generated account'):
         delete_confirmation_popup = acc_view.click_remove_account_button()
-        delete_confirmation_popup.click_remove_account_button()
+        delete_confirmation_popup.remove_account_with_confirmation()
 
     with step('Verify toast message notification when removing account'):
         messages = ToastMessage().get_toast_messages

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
@@ -18,16 +18,20 @@ from gui.screens.settings import SettingsScreen
                                         string.digits, k=40)))
 ])
 def test_settings_edit_status_account(main_screen: MainWindow, new_name):
-    with step('Open profile and wallet setting and check that display name equals to Status keypair name'):
-        status_keypair_title = \
-            main_screen.left_panel.open_settings().left_panel.open_wallet_settings().get_keypairs_names()[0]
+    with step('Open profile and wallet setting and check the keypairs list is not empty'):
+            settings = main_screen.left_panel.open_settings().left_panel.open_wallet_settings()
+            assert settings.get_keypairs_names !=0, f'Keypairs are not displayed'
+
+    with step('Verify Status keypair title'):
+        status_keypair_title = settings.get_keypairs_names()[0]
         profile_display_name = main_screen.left_panel.open_settings().left_panel.open_profile_settings().display_name
         assert profile_display_name in status_keypair_title, \
             f"Status keypair name should be equal to display name but currently it is {status_keypair_title}, \
              when display name is {profile_display_name}"
 
-    status_acc_view = (
-        SettingsScreen().left_panel.open_wallet_settings().open_status_account_in_settings())
+    with step('Open Status account view in wallet settings'):
+        status_acc_view = (
+            SettingsScreen().left_panel.open_wallet_settings().open_status_account_in_settings())
 
     with step('Check the default values on the account details view for Status account'):
         assert status_acc_view.get_account_name_value() == WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value, \

--- a/tests/wallet_main_screen/test_send.py
+++ b/tests/wallet_main_screen/test_send.py
@@ -31,6 +31,7 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.parametrize('receiver_account_address, amount, asset', [
     pytest.param(constants.user.user_account_one.status_address, 0, 'Ether')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12987")
 def test_wallet_send_0_eth(keys_screen, main_window, user_account, receiver_account_address, amount, asset):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()


### PR DESCRIPTION
https://ci.status.im/job/status-desktop/job/qa-automation/job/prs/job/PR-378/23/allure/

<img width="1840" alt="Screenshot 2023-12-13 at 15 42 37" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/16f7fabb-448f-42de-925a-f2641298b931">


I can reproduce the UI issues on my Linux machine as well

In this branch i tried to solve them. I really hope they all will be gone after upgrade to QT 5.15.10 on Linux so all these tweaks wont be necessary

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1205/allure/#suites/804b25da7c0d1c4c7f8a050c6a89e043/e047a6e57785f1f0/

Overall the test mode **is NOT yet enabled**. I am waiting for https://github.com/status-im/status-desktop/pull/9232 to test it there

- in `test_edit_community` added time.sleep when we load from for community overview and the same small time sleep when we start building the list of communities on settings screen
- in `test_community_category` i added attempts to click the button
- in `test_community_channels` fixed reference to community screen
- split `test_settings_messaging_accept_reject_contact_request` to 2
- disabled send test because of rate limit https://github.com/status-im/status-desktop/issues/12987
- fixed test to delete account in wallet settings according new designs
- some other minor tweaks
