### PR TITLE
chore: select tests to run against PRs

### DIFF
--- a/gui/components/change_password_popup.py
+++ b/gui/components/change_password_popup.py
@@ -1,5 +1,6 @@
 import allure
 
+import driver
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
 from gui.elements.text_edit import TextEdit
@@ -15,10 +16,26 @@ class ChangePasswordPopup(BasePopup):
         self._submit_button = Button('change_password_menu_submit_button')
         self._quit_button = Button('change_password_success_menu_sign_out_quit_button')
 
-    @allure.step('Change password and confirm action')
+    @allure.step('Fill in the form, submit and sign out')
     def change_password(self, old_pwd: str, new_pwd: str):
         self._current_password_text_field.text = old_pwd
         self._new_password_text_field.text = new_pwd
         self._confirm_password_text_field.text = new_pwd
         self._submit_button.click()
-        self._quit_button.wait_until_appears(15000).click()
+        self.click_sign_out_and_quit_button()
+
+    @allure.step('Wait for Sign out and quit button and click it')
+    def click_sign_out_and_quit_button(self):
+        """
+        Timeout is set as rough estimation of 15 seconds. What is happening when changing password is
+        the process of re-hasing DB initiated. Taking into account the user is new , so DB is relatively small
+        I assume, 15 seconds should be enough to finish re-hashing and show the Sign-out and quit button
+        This time is not really predictable, especially for huge DBs. We might implement other solution, but since
+        this wait_until_appears method is barely working, I suggest this solution for now
+        """
+        try:
+            assert driver.waitFor(lambda: self._quit_button.is_visible, 15000), \
+                f'Sign out and quit button is not visible within 15 seconds'
+            self._quit_button.click()
+        except Exception as ex:
+            raise ex

--- a/gui/components/change_password_popup.py
+++ b/gui/components/change_password_popup.py
@@ -37,5 +37,5 @@ class ChangePasswordPopup(BasePopup):
             assert driver.waitFor(lambda: self._quit_button.is_visible, 15000), \
                 f'Sign out and quit button is not visible within 15 seconds'
             self._quit_button.click()
-        except Exception as ex:
+        except (Exception, AssertionError) as ex:
             raise ex

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -573,7 +573,6 @@ class LoginView(QObject):
 
         self._password_text_edit.text = account.password
         self._arrow_right_button.click()
-        self.wait_until_hidden()
 
     @allure.step('Select user')
     def select_user_name(self, user_name, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,4 +21,5 @@ markers =
     onboarding: All tests related to onboarding
     keycard: All tests related to Keycard functionality
     wallet: All tests related to wallet functionality
+    online_identifier: All tests related to online_identifier functionality
 

--- a/tests/communities/test_airdrops.py
+++ b/tests/communities/test_airdrops.py
@@ -7,7 +7,6 @@ import constants
 from constants.community_settings import AirdropsElements
 from constants.images_paths import AIRDROPS_WELCOME_IMAGE_PATH
 from gui.main_window import MainWindow
-from scripts.tools import image
 
 pytestmark = marks
 
@@ -15,7 +14,6 @@ pytestmark = marks
                  'Manage community: Manage Airdrops screen overview')
 @pytest.mark.case(703200)
 @pytest.mark.parametrize('params', [constants.community_params])
-@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/186')
 def test_airdrops_screen(main_screen: MainWindow, params):
     with step('Create community'):
         main_screen.create_community(params)

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -11,6 +11,7 @@ from gui.main_window import MainWindow
 
 pytestmark = marks
 
+
 @pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703084', 'Create community')
 @pytest.mark.case(703084)
@@ -44,7 +45,7 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         community = community_settings.get_community_info(params['name'])
         assert community.name == params['name']
         assert community.description == params['description']
-        # assert '1' in community.members TODO: Test on linux, members label is not visible
+        assert '1' in community.members
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703056', 'Edit community separately')

--- a/tests/communities/test_communities_categories.py
+++ b/tests/communities/test_communities_categories.py
@@ -4,12 +4,15 @@ from allure_commons._allure import step
 
 import constants
 from gui.main_window import MainWindow
+from . import marks
+
+pytestmark = marks
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703226', 'Add category')
 @pytest.mark.case(703226)
 @pytest.mark.parametrize('category_name, general_checkbox', [
-    pytest.param('Category in general', True),
+    pytest.param('Category in general', True, marks=pytest.mark.critical),
     pytest.param('Category out of general', False)
 ])
 def test_create_community_category(main_screen: MainWindow, category_name, general_checkbox):
@@ -36,7 +39,8 @@ def test_remove_community_category(main_screen: MainWindow, category_name, gener
         community_screen.verify_category(category_name)
 
     with step('Create channel inside category'):
-        community_screen.left_panel.open_new_channel_popup_in_category().create(channel_name, channel_description, channel_emoji)
+        community_screen.left_panel.open_new_channel_popup_in_category().create(channel_name, channel_description,
+                                                                                channel_emoji)
 
     with step('Delete category'):
         community_screen.delete_category()

--- a/tests/communities/test_communities_channels.py
+++ b/tests/communities/test_communities_channels.py
@@ -4,7 +4,7 @@ from allure_commons._allure import step
 
 import constants
 from gui.main_window import MainWindow
-from gui.screens.community import CommunityScreen
+from . import marks
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703049', 'Create community channel')
@@ -62,7 +62,6 @@ def test_edit_community_channel(main_screen, channel_name, channel_description, 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703051', 'Delete community channel')
 @pytest.mark.case(703051)
 def test_delete_community_channel(main_screen):
-
     with step('Create simple community'):
         main_screen.create_community(constants.community_params)
         community_screen = main_screen.left_panel.select_community(constants.community_params['name'])

--- a/tests/communities/test_permissions.py
+++ b/tests/communities/test_permissions.py
@@ -16,7 +16,6 @@ pytestmark = marks
                  'Manage community: Manage Permissions screen overview')
 @pytest.mark.case(703198)
 @pytest.mark.parametrize('params', [constants.community_params])
-@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/186')
 def test_permissions_screen_overview(main_screen: MainWindow, params):
     main_screen.create_community(params)
 

--- a/tests/communities/test_tokens.py
+++ b/tests/communities/test_tokens.py
@@ -11,11 +11,11 @@ from scripts.tools import image
 
 pytestmark = marks
 
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703199',
                  'Manage community: Manage Mint Tokens screen overview')
 @pytest.mark.case(703199)
 @pytest.mark.parametrize('params', [constants.community_params])
-@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/186')
 def test_tokens_screen(main_screen: MainWindow, params):
     with step('Create community'):
         main_screen.create_community(params)

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -14,7 +14,6 @@ from gui.components.splash_screen import SplashScreen
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, BiometricsView, KeysView
 
 pytestmark = marks
-LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -34,7 +33,6 @@ def keys_screen(main_window) -> KeysView:
     pytest.param('Test-User', '*P@ssw0rd*', 'tv_signal.png', 5, shift_image(0, 0, 0, 0)),
     pytest.param('_1Test-User', '*P@ssw0rd*', 'tv_signal.jpeg', 5, shift_image(0, 1000, 1000, 0))
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/218")
 def test_generate_new_keys(main_window, keys_screen, user_name: str, password, user_image: str, zoom: int, shift):
     with step(f'Setup profile with name: {user_name} and image: {user_image}'):
 
@@ -50,19 +48,6 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
     with step('Open Profile details view and verify user info'):
 
         details_view = profile_view.next()
-        # TODO: temp removing tesseract usage because it is not stable
-        # if user_image is None:
-        #    assert not details_view.is_user_image_background_white()
-        #    assert driver.waitFor(
-        #        lambda: details_view.is_user_image_contains(user_name[:2]),
-        #        configs.timeouts.UI_LOAD_TIMEOUT_MSEC
-        #    )
-        # else:
-        #    image.compare(
-        #        details_view.cropped_profile_image,
-        #        f'{user_image.split(".")[1]}_onboarding.png',
-        #        threshold=0.9
-        #    )
         chat_key = details_view.chat_key
         emoji_hash = details_view.emoji_hash
         assert details_view.is_identicon_ring_visible
@@ -87,28 +72,9 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
 
         user_canvas = main_window.left_panel.open_online_identifier()
         assert user_canvas.user_name == user_name
-        # TODO: temp removing tesseract usage because it is not stable
-    # if user_image is None:
-    #     assert driver.waitFor(
-    #         lambda: user_canvas.is_user_image_contains(user_name[:2]),
-    #         configs.timeouts.UI_LOAD_TIMEOUT_MSEC
-    #     )
 
     with step('Open Profile popup and verify user info'):
 
         profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_name
         assert profile_popup.chat_key == chat_key
-        assert profile_popup.emoji_hash.compare(emoji_hash.view, threshold=0.9)
-        # TODO: temp removing tesseract usage because it is not stable
-        # if user_image is None:
-        #    assert driver.waitFor(
-        #        lambda: profile_popup.is_user_image_contains(user_name[:2]),
-        #        configs.timeouts.UI_LOAD_TIMEOUT_MSEC
-        #    )
-        # else:
-        #    image.compare(
-        #        profile_popup.cropped_profile_image,
-        #        f'{user_image.split(".")[1]}_profile.png',
-        #        threshold=0.9
-        #    )

--- a/tests/online_identifier/__init__.py
+++ b/tests/online_identifier/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+marks = pytest.mark.online_identifier

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -5,8 +5,9 @@ from allure import step
 import constants
 from driver.aut import AUT
 from gui.main_window import MainWindow
+from . import marks
 
-pytestmark = allure.suite("Settings")
+pytestmark = marks
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703007',

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -18,6 +18,8 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
+@pytest.mark.flaky
+# reason = 'https://github.com/status-im/status-desktop/issues/13013
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings'):
         settings_scr = main_screen.left_panel.open_settings().left_panel.open_profile_settings()

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -9,13 +9,14 @@ from gui.main_window import MainWindow
 
 pytestmark = marks
 
+@pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')
 @pytest.mark.case(703005)
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
-@pytest.mark.skip(reason="unstable")
+
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings and change password'):
         main_screen.left_panel.open_settings().left_panel.open_profile_settings().open_change_password_popup().change_password(

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -1,4 +1,5 @@
 import allure
+import psutil
 import pytest
 from allure_commons._allure import step
 from . import marks
@@ -9,6 +10,7 @@ from gui.main_window import MainWindow
 
 pytestmark = marks
 
+
 @pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')
@@ -16,17 +18,27 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
-
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
-    with step('Open profile settings and change password'):
-        main_screen.left_panel.open_settings().left_panel.open_profile_settings().open_change_password_popup().change_password(
+    with step('Open profile settings'):
+        settings_scr = main_screen.left_panel.open_settings().left_panel.open_profile_settings()
+
+    with step('Open change password popup'):
+        change_psw_pop_up = settings_scr.open_change_password_popup()
+
+    with step('Fill in the change password form and submit'):
+        change_psw_pop_up.change_password(
             user_account.password, user_account_changed_password.password)
+
+    with step('Verify the application process is not running'):
+        psutil.Process(aut.pid).wait(timeout=10)
 
     with step('Restart application'):
         aut.restart()
+
+    with step('Login with new password'):
         main_screen.authorize_user(user_account_changed_password)
 
     with step('Verify that the user logged in correctly'):
-        user_canvas = main_screen.left_panel.open_online_identifier()
-        profile_popup = user_canvas.open_profile_popup_from_online_identifier()
+        online_identifier = main_screen.left_panel.open_online_identifier()
+        profile_popup = online_identifier.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -16,6 +16,7 @@ from gui.main_window import MainWindow
 from gui.screens.settings_wallet import WalletSettingsView
 
 pytestmark = marks
+@pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704454',
                  'Account view interactions: Delete generated account')
 @pytest.mark.case(704454)

--- a/tests/settings/test_settings_back_up_seed.py
+++ b/tests/settings/test_settings_back_up_seed.py
@@ -9,6 +9,7 @@ from gui.components.back_up_your_seed_phrase_banner import BackUpSeedPhraseBanne
 from gui.main_window import MainWindow
 
 pytestmark = marks
+@pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703001', 'Backup seed phrase')
 @pytest.mark.case(703001)
 def test_back_up_seed_phrase(main_screen: MainWindow):

--- a/tests/settings/test_settings_sign_out_and_quit.py
+++ b/tests/settings/test_settings_sign_out_and_quit.py
@@ -8,6 +8,7 @@ from . import marks
 pytestmark = marks
 
 
+@pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703010', 'Settings - Sign out & Quit')
 @pytest.mark.case(703010)
 @pytest.mark.flaky
@@ -22,3 +23,4 @@ def test_sign_out_and_quit(aut, main_screen: MainWindow):
 
     with step('Check that app was closed'):
         psutil.Process(aut.pid).wait(timeout=10)
+        

--- a/tests/wallet_main_screen/test_context_menu_manage_watched_address.py
+++ b/tests/wallet_main_screen/test_context_menu_manage_watched_address.py
@@ -11,6 +11,7 @@ from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 pytestmark = marks
+@pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703026',
                  'Manage a watch-only account from context menu option')
 @pytest.mark.case(703026)


### PR DESCRIPTION
1. Selected a few tests to run by `critical` mark in PRs (`pytest -m critical`)

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1213/

<img width="1840" alt="Screenshot 2023-12-13 at 19 35 23" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/181a7162-68bf-4e7b-8c7a-878abec8f21c">

If this selection is good, i will make the corresponding change in status-desktop repo, so in desktop PRs , we will run these 8 tests for now

2. Improved the change password test a bit, because it hangs for 15 minutes (https://ci.status.im/job/status-desktop/job/e2e/job/manual/1215/allure/#suites/67eac0031245ff48294e4d11dc8f3332/b19140088c319653/)

<img width="1567" alt="Screenshot 2023-12-15 at 17 49 46" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/0a9167cb-0083-4810-806c-f7d36aa0a4bc">

