### PR TITLE
chore: replace is_visible

### DIFF
--- a/gui/screens/community_portal.py
+++ b/gui/screens/community_portal.py
@@ -1,5 +1,6 @@
 import allure
 
+import driver
 from gui.components.community.create_community_popups import CreateCommunitiesBanner, CreateCommunityPopup
 from gui.elements.button import Button
 from gui.elements.object import QObject
@@ -14,4 +15,9 @@ class CommunitiesPortal(QObject):
     @allure.step('Open create community popup')
     def open_create_community_popup(self) -> CreateCommunityPopup:
         self._create_community_button.click()
-        return CreateCommunitiesBanner().wait_until_appears().open_create_community_popup()
+        try:
+            assert driver.waitForObjectExists(CreateCommunitiesBanner().real_name, 5000), \
+                f'Create community banner is not present within 5 seconds'
+        except (Exception, AssertionError) as ex:
+            raise ex
+        return CreateCommunitiesBanner().open_create_community_popup()

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -96,7 +96,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
         with step('Verify user details are the same with user in first instance'):
             online_identifier = main_window.left_panel.open_online_identifier()
             assert online_identifier.get_user_name == user.name, \
-                f'Name in online identifier and display do not match'
+                f'Name in online identifier and display name do not match'
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703631', 'Wrong sync code')


### PR DESCRIPTION
Community categories tests got stuck for 15 minutes because of `wait_until_appears` method

https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/134/allure/ (nightly run)

CI run with critical mark https://ci.status.im/job/status-desktop/job/e2e/job/manual/1236/

<img width="1840" alt="Screenshot 2023-12-23 at 10 32 51" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/b284e36a-09f9-48bc-8608-6458b36a023b">

CI run with all communities suite
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1237/console

<img width="1840" alt="Screenshot 2023-12-23 at 10 40 25" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/fd6993eb-c07c-4c87-ad71-8de19eb2f790">

