### PR TITLE
Introduce pytest timeout mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ it will be shown as XPASS (unexpectedly passing) in report, which will indicate 
 if will be shown as passed in report normally. If the test fails, then the total run wont be failed, but 
 the corresponding test will be marked as `xfail` in the report. It is done for a few tests that are not super
 stable yet, but passes most of the time. This mark should be used with caution and in case of real need only.
+- `timeout(timeout=180, method="thread")`, to catch excessively long test durations like deadlocked or hanging tests.
+This is done by `pytest-timeout` plugin

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,4 +20,5 @@ markers =
     keycard: All tests related to Keycard functionality
     wallet: All tests related to wallet functionality
     online_identifier: All tests related to online_identifier functionality
+    timeout: Apply timeout when test is running longer than expected
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ testrail-api==1.12.0
 pyperclip==1.8.2
 pytest-rerunfailures==11.1.2
 pytest-ignore-flaky==2.1.0
+pytest-timeout==2.2.0

--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -11,6 +11,7 @@ from gui.main_window import MainWindow
 pytestmark = marks
 
 
+@pytest.mark.timeout(timeout=180, method="thread")
 @pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')


### PR DESCRIPTION
Motivation: do not spent extra 15 minutes on nothing
Fixes https://github.com/status-im/desktop-qa-automation/issues/413

https://pypi.org/project/pytest-timeout/

https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/137/allure/

<img width="2032" alt="Screenshot 2023-12-26 at 18 01 52" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/d279f6d3-29c4-43fc-af8c-d0d6cf274a75">




<img width="2032" alt="Screenshot 2023-12-26 at 17 58 19" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/bee0a5dc-302f-494c-8b73-231e3b0ffb18">

In case of test hangs, it will be timed out within given timeout value. Right now i set this mark for only 1 test

`@pytest.mark.timeout(timeout=180, method="thread")`, timeout is set for 3 minutes (could be reduced later, lets see)

I did not set any default timeout across the framework yet. it could be done later in pytest.ini file