### PR TITLE
chore: add timeout for group chat

### DIFF
--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -12,13 +12,14 @@ from gui.screens.messages import MessagesScreen
 
 pytestmark = marks
 
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703014', 'Create a group and send messages')
 @pytest.mark.case(703014)
+@pytest.mark.timeout(timeout=240)
 @pytest.mark.parametrize('user_data_one, user_data_two, user_data_three', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two',
      configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/12440")
 def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_three):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two


### PR DESCRIPTION
Group chat test was stuck in last nightly and its duration was 36m 53s

https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/139/allure/#testresult/5f9296a7ddfa5053

![image](https://github.com/status-im/desktop-qa-automation/assets/82375995/05a36b99-7505-4482-9af4-eb44d0373d1a)

I am setting this test to force timeout after 240 seconds (4 minutes). Normally this test passes within ~3 minutes, so i am adding extra minute just in case. Anyhow. 36 minutes is crazy
