### PR TITLE
chore: fix test for creating permissions

### DIFF
--- a/constants/community_settings.py
+++ b/constants/community_settings.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class PermissionsElements(Enum):
     WELCOME_TITLE = "Permissions"
     WELCOME_SUBTITLE = 'You can manage your community by creating and issuing membership and access permissions'
@@ -26,3 +27,7 @@ class AirdropsElements(Enum):
     WELCOME_CHECKLIST_ELEMENT_3 = 'Require holding a token or NFT to obtain exclusive membership rights'
     INFOBOX_TITLE = 'Get started'
     INFOBOX_TEXT = 'In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.'
+
+
+class ToastMessages(Enum):
+    CREATE_PERMISSION_TOAST = 'Community permission created'

--- a/constants/user.py
+++ b/constants/user.py
@@ -18,12 +18,15 @@ user_account_one_changed_password = UserAccount('squisher', 'NewPassword@12345',
 user_account_one_changed_name = UserAccount('NewUserName', '0000000000', [], '')
 
 user_with_funds = UserAccount('User_with_funds', '0000000000', [
-    'vocal', 'fruit', 'ordinary', 'meadow', 'south', 'athlete', 'inherit', 'since', 'version', 'pitch', 'oppose', 'lonely'
+    'vocal', 'fruit', 'ordinary', 'meadow', 'south', 'athlete', 'inherit', 'since', 'version', 'pitch', 'oppose',
+    'lonely'
 ], '0x26d6e10a6af4eb4d12ff4cf133a843eb4fa88d0b')
 
 community_params = {
-    'name': 'Name',
-    'description': 'Description',
+    'name': ''.join(random.choices(string.ascii_letters +
+                                   string.digits, k=30)),
+    'description': ''.join(random.choices(string.ascii_letters +
+                                    string.digits, k=140)),
     'logo': {'fp': configs.testpath.TEST_FILES / 'tv_signal.png', 'zoom': None, 'shift': None},
     'banner': {'fp': configs.testpath.TEST_FILES / 'banner.png', 'zoom': None, 'shift': None},
     'intro': ''.join(random.choices(string.ascii_letters +

--- a/gui/objects_map/community_names.py
+++ b/gui/objects_map/community_names.py
@@ -122,9 +122,12 @@ communityItem_CommunityListItem = {"container": statusDesktop_mainWindow_overlay
 editPermissionView_switchItem_StatusSwitch = {"checkable": True, "container": mainWindow_editPermissionView_EditPermissionView, "id": "switchItem", "type": "StatusSwitch", "unnamed": 1, "visible": True}
 editPermissionView_Create_permission_StatusButton = {"checkable": False, "container": mainWindow_editPermissionView_EditPermissionView, "text": "Create permission", "type": "StatusButton", "unnamed": 1, "visible": True}
 mainWindow_PermissionsView = {"container": statusDesktop_mainWindow, "type": "PermissionsView", "unnamed": 1, "visible": True}
-o_StatusListItemTag = {"container": mainWindow_PermissionsView, "type": "StatusListItemTag", "unnamed": 1, "visible": True}
+o_StatusListItemTag = {"container": mainWindow_PermissionsView, "type": "StatusListItemTag", "visible": True}
 o_IntroPanel = {"container": mainWindow_PermissionsView, "type": "IntroPanel", "unnamed": 1, "visible": True}
 mainWindow_PermissionsSettingsPanel = {"container": statusDesktop_mainWindow, "type": "PermissionsSettingsPanel", "unnamed": 1, "visible": True}
+whoHoldsTagListItem = {"container": mainWindow_PermissionsView, "objectName": "whoHoldsStatusListItem", "type": "StatusListItemTag", "visible": True}
+isAllowedTagListItem = {"container": mainWindow_PermissionsView, "objectName": "isAllowedStatusListItem", "type": "StatusListItemTag", "visible": True}
+inCommunityTagListItem = {"container": mainWindow_PermissionsView, "objectName": "inCommunityStatusListItem", "type": "StatusListItemTag", "visible": True}
 
 # Edit Community
 mainWindow_communityEditPanelScrollView_EditSettingsPanel = {"container": statusDesktop_mainWindow, "objectName": "communityEditPanelScrollView", "type": "EditSettingsPanel", "visible": True}

--- a/gui/screens/community_settings.py
+++ b/gui/screens/community_settings.py
@@ -94,9 +94,10 @@ class OverviewView(QObject):
             return EditCommunityView()
         except Exception as ex:
             if attempts:
-                self.open_edit_community_view(attempts-1)
+                self.open_edit_community_view(attempts - 1)
             else:
                 raise ex
+
 
 class EditCommunityView(QObject):
 
@@ -399,12 +400,24 @@ class PermissionsSettingsView(QObject):
         self._is_allowed_to_list_item = QObject('editPermissionView_Is_allowed_to_StatusFlowSelector')
         self._in_list_item = QObject('editPermissionView_In_StatusItemSelector')
         self._tag_item = QObject('o_StatusListItemTag')
+        self._who_holds_tag = QObject('whoHoldsTagListItem')
+        self._is_allowed_tag = QObject('isAllowedTagListItem')
+        self._in_community_in_channel_tag = QObject('inCommunityTagListItem')
 
-    @property
-    @allure.step('Get permission tags')
-    def tags(self) -> typing.List[str]:
-        _tags = driver.findAllObjects(self._tag_item.real_name)
-        return [str(getattr(tag, 'title', '')) for tag in _tags]
+    @allure.step('Get titles of Who holds tags')
+    def get_who_holds_tags_titles(self) -> typing.List[str]:
+        who_holds_tags = [str(tag.title) for tag in driver.findAllObjects(self._who_holds_tag.real_name)]
+        return who_holds_tags
+
+    @allure.step('Get titles of Is Allowed tags')
+    def get_is_allowed_tags_titles(self) -> typing.List[str]:
+        is_allowed_tags = [str(tag.title) for tag in driver.findAllObjects(self._is_allowed_tag.real_name)]
+        return is_allowed_tags
+
+    @allure.step('Get title of inCommunity tag')
+    def get_in_community_in_channel_tags_titles(self) -> typing.List[str]:
+        in_community_in_channel_tags = [str(tag.title) for tag in driver.findAllObjects(self._in_community_in_channel_tag.real_name)]
+        return in_community_in_channel_tags
 
     @allure.step('Set state of who holds checkbox')
     def set_who_holds_checkbox_state(self, state):
@@ -420,7 +433,6 @@ class PermissionsSettingsView(QObject):
             self._who_holds_asset_field.wait_until_hidden()
             self._who_holds_amount_field.text = amount
             self._add_button.click()
-            self._who_holds_amount_field.wait_until_hidden()
 
     @allure.step('Choose option from Is allowed to context menu')
     def set_is_allowed_to(self, name):
@@ -428,7 +440,6 @@ class PermissionsSettingsView(QObject):
         self._is_allowed_to_option_button.real_name['objectName'] = name
         self._is_allowed_to_option_button.wait_until_appears().click()
         self._add_button.click()
-        self._add_button.wait_until_hidden()
 
     @allure.step('Choose channel from In context menu')
     def set_in(self, in_general):
@@ -436,7 +447,6 @@ class PermissionsSettingsView(QObject):
             self.open_in_context_menu()
             self._in_general_button.wait_until_appears().click()
             self._add_button.click()
-            self._add_button.wait_until_hidden()
 
     @allure.step('Click create permission')
     def create_permission(self):

--- a/tests/communities/test_permissions.py
+++ b/tests/communities/test_permissions.py
@@ -1,11 +1,13 @@
 import allure
 import pytest
 from allure_commons._allure import step
+
+from gui.components.toast_message import ToastMessage
 from . import marks
 
 import constants
 import driver
-from constants.community_settings import PermissionsElements
+from constants.community_settings import PermissionsElements, ToastMessages
 from constants.images_paths import PERMISSION_WELCOME_IMAGE_PATH
 from gui.main_window import MainWindow
 
@@ -42,7 +44,8 @@ def test_permissions_screen_overview(main_screen: MainWindow, params):
 @pytest.mark.case(703632)
 @pytest.mark.parametrize('params', [constants.community_params])
 @pytest.mark.parametrize(
-    'checkbox_state, first_asset, second_asset, amount, allowed_to, in_general, asset_title, second_asset_title, allowed_to_title',
+    'checkbox_state, first_asset, second_asset, amount, allowed_to, in_channel, asset_title, second_asset_title, '
+    'allowed_to_title',
     [
         pytest.param(True, 'Dai Stablecoin', False, '10', 'becomeMember', False, '10 DAI', False, 'Become member'),
         pytest.param(True, 'Ether', False, '1', 'becomeAdmin', False, '1 ETH', False, 'Become an admin'),
@@ -51,9 +54,9 @@ def test_permissions_screen_overview(main_screen: MainWindow, params):
         pytest.param(True, 'Ether', 'Dai Stablecoin', '10', 'viewOnly', '#general', '10 ETH', '10 DAI', 'View only'),
         pytest.param(False, False, False, False, 'becomeAdmin', False, False, False, 'Become an admin')
     ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/167")
+
 def test_adding_permissions(main_screen: MainWindow, params, checkbox_state: bool, first_asset, second_asset, amount,
-                            allowed_to: str, in_general, asset_title, second_asset_title, allowed_to_title: str):
+                            allowed_to: str, in_channel, asset_title, second_asset_title, allowed_to_title: str):
     main_screen.create_community(params)
 
     with step('Open add new permission page'):
@@ -66,13 +69,26 @@ def test_adding_permissions(main_screen: MainWindow, params, checkbox_state: boo
         permissions_settings.set_who_holds_asset_and_amount(first_asset, amount)
         permissions_settings.set_who_holds_asset_and_amount(second_asset, amount)
         permissions_settings.set_is_allowed_to(allowed_to)
-        permissions_settings.set_in(in_general)
+        permissions_settings.set_in(in_channel)
         permissions_settings.create_permission()
+
+    with step('Check toast message for permission creation'):
+        assert len(ToastMessage().get_toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = ToastMessage().get_toast_messages[0]
+        assert message == ToastMessages.CREATE_PERMISSION_TOAST.value, \
+            f"Toast message is incorrect, current message is {message}"
 
     with step('Created permission is displayed on permission page'):
         if asset_title is not False:
-            assert driver.waitFor(lambda: asset_title in permissions_settings.tags)
+            assert driver.waitFor(lambda: asset_title in permissions_settings.get_who_holds_tags_titles())
         if second_asset_title is not False:
-            assert driver.waitFor(lambda: second_asset_title in permissions_settings.tags)
+            assert driver.waitFor(lambda: second_asset_title in permissions_settings.get_who_holds_tags_titles())
         if allowed_to_title is not False:
-            assert driver.waitFor(lambda: allowed_to_title in permissions_settings.tags)
+            assert driver.waitFor(lambda: allowed_to_title in permissions_settings.get_is_allowed_tags_titles())
+        if in_channel is False:
+            assert driver.waitFor(lambda: params['name'] in permissions_settings.get_in_community_in_channel_tags_titles())
+        if in_channel:
+            assert driver.waitFor(lambda: in_channel in permissions_settings.get_in_community_in_channel_tags_titles())
+
+


### PR DESCRIPTION
**Fixes** https://github.com/status-im/desktop-qa-automation/issues/421
**Depends** on https://github.com/status-im/status-desktop/pull/13110

1. add randomisation for community name and description when creating
2. added toast message verification step
3. added methods to verify tags specifically
4. added verification for `in_channel`, `in_community`

**Todo:** 
- remove parametrisation and use test sets inside the test (to reduce test time)
- to create a test for critical suite (perhaps break this one into several, 1 test will be marked as critical)

**ci run:** https://ci.status.im/job/status-desktop/job/e2e/job/manual/1249/

**allure:** https://ci.status.im/job/status-desktop/job/e2e/job/manual/1249/allure/#suites/a9b9ce4ef70730fb5814a5009e98b445

<img width="1840" alt="Screenshot 2023-12-28 at 21 54 12" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/463dd926-63a4-4adf-9721-922365cae026">
