### PR TITLE
chore: remove change password test from critical suite

### DIFF
--- a/tests/settings/settings_profile/test_settings_profile_change_password.py
+++ b/tests/settings/settings_profile/test_settings_profile_change_password.py
@@ -11,16 +11,15 @@ from gui.main_window import MainWindow
 pytestmark = marks
 
 
-@pytest.mark.timeout(timeout=180, method="thread")
-@pytest.mark.critical
+@pytest.mark.timeout(timeout=180)
+# @pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')
 @pytest.mark.case(703005)
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
-@pytest.mark.flaky
-# reason = 'https://github.com/status-im/status-desktop/issues/13013
+@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13013')
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings'):
         settings_scr = main_screen.left_panel.open_settings().left_panel.open_profile_settings()


### PR DESCRIPTION
Remove `@pytest.critical` mark from `test_settings_profile_change_password.py`. The test is timing out very often now (addressed in https://github.com/status-im/status-desktop/issues/13013) which indicates the run against PRs in desktop repository as failures. I want to make this selection of tests (by `critical` mark) to be always green, so we finally switch off old tests and start relying on new ones

This test will be still executed in nightly runs


<img width="1840" alt="Screenshot 2024-01-10 at 11 39 10" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/88e9ba4f-37da-471a-82a2-7cb30424570a">
