### PR TITLE
chore: add multiple references for tests

### DIFF
--- a/tests/settings/test_settings_sign_out_and_quit.py
+++ b/tests/settings/test_settings_sign_out_and_quit.py
@@ -10,7 +10,8 @@ pytestmark = marks
 
 @pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703010', 'Settings - Sign out & Quit')
-@pytest.mark.case(703010)
+# TODO: Experimental link for testing multiple references in test rail report by nightly job. Has to be removed!
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704620', 'Wallet -> Settings -> Saved addresses: Add new saved address')
 @pytest.mark.flaky
 # reason='https://github.com/status-im/status-desktop/issues/13013'
 def test_sign_out_and_quit(aut, main_screen: MainWindow):


### PR DESCRIPTION
This is an experimental thing:

1. removed `pytest.mark.case` marker in 1 test. I cant find any documentation about this marker in official docs or `pytest.ini`
2. TEMP added a second link for a test case reference (`@allure.testcase`). Want to test how it would post the report from allure to test rail (and this is now possible only with nightly job). My expectation (and biggest hope) is that this move would allow us to map 1 automated script with multiple test cases in test rail