### PR TITLE
chore: replace methods of waiting views with methods of checking elements on these views

### DIFF
--- a/constants/onboarding.py
+++ b/constants/onboarding.py
@@ -10,6 +10,11 @@ class OnboardingMessages(Enum):
     PASSWORD_INCORRECT = 'Password incorrect'
 
 
+class OnboardingScreensHeaders(Enum):
+    YOUR_EMOJIHASH_AND_IDENTICON_RING_SCREEN_TITLE = 'Your emojihash and identicon ring'
+    YOUR_PROFILE_SCREEN_TITLE = 'Your profile'
+
+
 password_strength_elements = namedtuple('Password_Strength_Elements',
                                         ['strength_indicator', 'strength_color', 'strength_messages'])
 very_weak_lower_elements = password_strength_elements('Very weak', '#ff2d55', ['• Lower case'])

--- a/constants/wallet.py
+++ b/constants/wallet.py
@@ -62,3 +62,7 @@ class WalletOrigin(Enum):
 
 class WalletTransactions(Enum):
     TRANSACTION_PENDING_TOAST_MESSAGE = 'Transaction pending'
+
+
+class WalletScreensHeaders(Enum):
+    WALLET_ADD_ACCOUNT_POPUP_TITLE = 'Add a new account'

--- a/gui/components/wallet/wallet_account_popups.py
+++ b/gui/components/wallet/wallet_account_popups.py
@@ -18,7 +18,6 @@ from gui.elements.scroll import Scroll
 from gui.elements.text_edit import TextEdit
 from gui.elements.text_label import TextLabel
 
-
 GENERATED_PAGES_LIMIT = 20
 
 
@@ -49,6 +48,10 @@ class AccountPopup(BasePopup):
 
     def verify_account_popup_present(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
         driver.waitFor(lambda: self._popup_header_title.exists, timeout_msec)
+        assert (getattr(self._popup_header_title.object, 'text')
+                == WalletScreensHeaders.WALLET_ADD_ACCOUNT_POPUP_TITLE.value), \
+            f"AccountPopup is not shown or has wrong title, \
+                    current screen title is {getattr(self._popup_header_title.object, 'text')}"
         return self
 
     @allure.step('Set name for account')
@@ -160,7 +163,7 @@ class EditAccountFromSettingsPopup(BasePopup):
         if 'radioButtonColor' in self._color_radiobutton.real_name.keys():
             del self._color_radiobutton.real_name['radioButtonColor']
         colors = [str(item.radioButtonColor) for item in driver.findAllObjects(self._color_radiobutton.real_name)]
-        self._color_radiobutton.real_name['radioButtonColor'] =\
+        self._color_radiobutton.real_name['radioButtonColor'] = \
             random.choice([color for color in colors if color != '#2a4af5'])  # exclude status default color
         self._color_radiobutton.click()
         return self

--- a/gui/objects_map/onboarding_names.py
+++ b/gui/objects_map/onboarding_names.py
@@ -77,6 +77,7 @@ mainWindow_clear_icon_StatusIcon = {"container": mainWindow_StatusWindow, "objec
 mainWindow_welcomeScreenUserProfileImage_StatusSmartIdenticon = {"container": mainWindow_InsertDetailsView, "objectName": "welcomeScreenUserProfileImage", "type": "StatusSmartIdenticon", "visible": True}
 mainWindow_insertDetailsViewChatKeyTxt_StyledText = {"container": mainWindow_InsertDetailsView, "objectName": "insertDetailsViewChatKeyTxt", "type": "StyledText", "visible": True}
 mainWindow_EmojiHash = {"container": statusDesktop_mainWindow, "objectName": "publicKeyEmojiHash", "type": "EmojiHash", "visible": True}
+mainWindow_Header_Title = {"container": statusDesktop_mainWindow, "objectName": "onboardingHeaderText", "type": "StyledText", "visible": True}
 mainWindow_userImageCopy_StatusSmartIdenticon = {"container": mainWindow_InsertDetailsView, "id": "userImageCopy", "type": "StatusSmartIdenticon", "unnamed": 1, "visible": True}
 
 

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -7,6 +7,7 @@ import allure
 
 import configs
 import constants.tesseract
+from constants.onboarding import OnboardingScreensHeaders
 import driver
 from constants import ColorCodes
 from driver.objects_access import walk_children
@@ -77,7 +78,7 @@ class KeysView(OnboardingView):
     @allure.step('Open Profile view')
     def generate_new_keys(self) -> 'YourProfileView':
         self._generate_key_button.click()
-        return YourProfileView().wait_until_appears()
+        return YourProfileView().verify_profile_view_present()
 
     @allure.step('Open Keycard Init view')
     def generate_key_for_new_keycard(self) -> 'KeycardInitView':
@@ -265,6 +266,15 @@ class YourProfileView(OnboardingView):
         self._login_input_object = QObject('mainWindow_nameInput_StatusInput')
         self._clear_icon = QObject('mainWindow_clear_icon_StatusIcon')
         self._identicon_ring = QObject('mainWindow_IdenticonRing')
+        self._view_header_title = TextLabel('mainWindow_Header_Title')
+
+    def verify_profile_view_present(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        driver.waitFor(lambda: self._view_header_title.exists, timeout_msec)
+        assert (getattr(self._view_header_title.object, 'text') ==
+                OnboardingScreensHeaders.YOUR_PROFILE_SCREEN_TITLE.value) , \
+            f"YourProfileView is not shown or has wrong title, \
+            current screen title is {getattr(self._view_header_title.object, 'text')}"
+        return self
 
     @property
     @allure.step('Get next button enabled state')
@@ -309,11 +319,11 @@ class YourProfileView(OnboardingView):
         file_dialog.open_file(fp)
         return PictureEditPopup().wait_until_appears()
 
-    @allure.step('Open Emoji and Icon view')
+    @allure.step('Open Your Emoji hash and Identicon Ring View')
     def next(self, attempts: int = 2) -> 'YourEmojihashAndIdenticonRingView':
         self._next_button.click()
         try:
-            return YourEmojihashAndIdenticonRingView()
+            return YourEmojihashAndIdenticonRingView().verify_emojihash_view_present()
         except Exception as err:
             if attempts:
                 return self.next(attempts - 1)
@@ -335,6 +345,15 @@ class YourEmojihashAndIdenticonRingView(OnboardingView):
         self._next_button = Button('mainWindow_Next_StatusButton')
         self._emoji_hash = QObject('mainWindow_EmojiHash')
         self._identicon_ring = QObject('mainWindow_userImageCopy_StatusSmartIdenticon')
+        self._view_header_title = TextLabel('mainWindow_Header_Title')
+
+    def verify_emojihash_view_present(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        driver.waitFor(lambda: self._view_header_title.exists, timeout_msec)
+        assert (getattr(self._view_header_title.object, 'text') ==
+                OnboardingScreensHeaders.YOUR_EMOJIHASH_AND_IDENTICON_RING_SCREEN_TITLE.value) , \
+            f"YourEmojihashAndIdenticonRingView is not shown or has wrong title, \
+            current screen title is {getattr(self._view_header_title.object, 'text')}"
+        return self
 
     @property
     @allure.step('Get profile image icon')

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -41,7 +41,7 @@ class WalletSettingsView(QObject):
     def open_add_account_pop_up(self, attempts: int = 2) -> 'AccountPopup':
         self._wallet_settings_add_new_account_button.click()
         try:
-            return AccountPopup()
+            return AccountPopup().verify_account_popup_present()
         except Exception as ex:
             if attempts:
                 return self.open_add_account_pop_up(attempts - 1)

--- a/tests/wallet_main_screen/test_plus_button_add_watched_address.py
+++ b/tests/wallet_main_screen/test_plus_button_add_watched_address.py
@@ -18,7 +18,7 @@ pytestmark = marks
     pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                  'sunglasses', '1f60e')
 ])
-@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/12914")
+#@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/12914")
 def test_plus_button_add_watched_address(
         main_screen: MainWindow, address: str, color: str, emoji: str, emoji_unicode: str,
         name: str):


### PR DESCRIPTION
Onboarding CI run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1261/allure/#suites/8c8bad42b349ab7d648f7a8503fdb961/3ac4673cfec5e7d2/

Wallet CI run:https://ci.status.im/job/status-desktop/job/e2e/job/manual/1263/allure/#suites/96c8fa12a723416450fcec379bdcd5c0

- added verify_account_popup_present() function
- added verify_profile_view_present() function
- added verify_emojihash_view_present()

Mostly done as an attempt to fix flaky navigation in new keys test. (see https://ci.status.im/job/status-desktop/job/e2e/job/prs/1136/allure/#suites/c48b221cdcfecf89e1eb75d0b8e79672/f41783642f763391/)

So the test clicks Next button twice and then thinks he is already on next screen when it is not. So i added a verification for Profile and Emoji screens that when we returning these views, we first check screen titles and if they are correct - then proceed further

Same function is added for Add Account popup earlier, i forgot to add a call for it

Uncomment the test of adding watch only address, related issue seems to be fixed