### PR TITLE
chore: reporting test to 2 different test cases in Testrail

### DIFF
--- a/tests/settings/test_settings_sign_out_and_quit.py
+++ b/tests/settings/test_settings_sign_out_and_quit.py
@@ -12,8 +12,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703010', 'Settings - Sign out & Quit')
 # TODO: Experimental link for testing multiple references in test rail report by nightly job. Has to be removed!
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704620', 'Wallet -> Settings -> Saved addresses: Add new saved address')
-@pytest.mark.case(703010)
-@pytest.mark.case(704620)
+@pytest.mark.case(703010, 704620)
 @pytest.mark.flaky
 # reason='https://github.com/status-im/status-desktop/issues/13013'
 def test_sign_out_and_quit(aut, main_screen: MainWindow):


### PR DESCRIPTION
I tested it here https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/161/

Test report is here - https://ethstatus.testrail.net/index.php?/runs/view/14414&group_by=cases:section_id&group_order=asc 

So it was successfully reported to 2 test cases. Let's see how it works in nightly