### PR TITLE
chore: disable tests because of broken contact requests

### DIFF
--- a/tests/communities/test_join_community.py
+++ b/tests/communities/test_join_community.py
@@ -17,6 +17,7 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
+@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/13246")
 def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -20,6 +20,7 @@ pytestmark = marks
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two',
      configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
+@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/13246")
 def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_three):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
@@ -11,6 +11,8 @@ from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 pytestmark = marks
+
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703011', 'Add a contact with a chat key')
 @pytest.mark.case(703011)
 @pytest.mark.parametrize('user_data_one, user_data_two', [

--- a/tests/wallet_main_screen/test_plus_button_add_watched_address.py
+++ b/tests/wallet_main_screen/test_plus_button_add_watched_address.py
@@ -12,13 +12,14 @@ from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 pytestmark = marks
+
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703026', 'Manage a watch-only account')
 @pytest.mark.case(703026)
 @pytest.mark.parametrize('address, name, color, emoji, emoji_unicode', [
     pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                  'sunglasses', '1f60e')
 ])
-#@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/12914")
 def test_plus_button_add_watched_address(
         main_screen: MainWindow, address: str, color: str, emoji: str, emoji_unicode: str,
         name: str):


### PR DESCRIPTION
Contact requests are dead again in status.prod fleet 
Ticket logged: https://github.com/status-im/status-desktop/issues/13246