### PR TITLE
chore: enabling tests with contact requests

### DIFF
--- a/tests/communities/test_join_community.py
+++ b/tests/communities/test_join_community.py
@@ -17,7 +17,6 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13322')
 def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -20,7 +20,6 @@ pytestmark = marks
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two',
      configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13322')
 def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_three):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
@@ -20,7 +20,6 @@ pytestmark = marks
 ])
 @pytest.mark.flaky
 # reason='https://github.com/status-im/desktop-qa-automation/issues/346'
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13322')
 def test_messaging_settings_accepting_request(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
@@ -19,7 +19,6 @@ pytestmark = marks
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13322')
 def test_messaging_settings_identity_verification(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
@@ -14,7 +14,6 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13322')
 def test_messaging_settings_rejecting_request(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two


### PR DESCRIPTION
As contact requests works fine now, I'm enabling tests

CI runs:
https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/181/
https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/182/