### PR TITLE
chore: fix for failed tests and enabling some tests after bug fix

### DIFF
--- a/tests/communities/test_communities_channels.py
+++ b/tests/communities/test_communities_channels.py
@@ -32,7 +32,6 @@ def test_create_community_channel(main_screen: MainWindow, channel_name, channel
 @pytest.mark.case(703050)
 @pytest.mark.parametrize('channel_name, channel_description, channel_emoji, channel_emoji_image, channel_color',
                          [('Channel', 'Description', 'sunglasses', None, '#4360df')])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/475")
 def test_edit_community_channel(main_screen, channel_name, channel_description, channel_emoji, channel_emoji_image,
                                 channel_color):
     with step('Create simple community'):

--- a/tests/communities/test_join_community.py
+++ b/tests/communities/test_join_community.py
@@ -17,7 +17,6 @@ from gui.main_window import MainWindow
 @pytest.mark.parametrize('user_data_one, user_data_two', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13375')
 def test_join_community_via_owner_invite(multiple_instance, user_data_one, user_data_two):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two

--- a/tests/messages/test_messaging_group_chat.py
+++ b/tests/messages/test_messaging_group_chat.py
@@ -15,12 +15,11 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703014', 'Create a group and send messages')
 @pytest.mark.case(703014)
-@pytest.mark.timeout(timeout=240)
+@pytest.mark.timeout(timeout=265)
 @pytest.mark.parametrize('user_data_one, user_data_two, user_data_three', [
     (configs.testpath.TEST_USER_DATA / 'user_account_one', configs.testpath.TEST_USER_DATA / 'user_account_two',
      configs.testpath.TEST_USER_DATA / 'user_account_two')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/desktop-qa-automation/issues/475")
 def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_three):
     user_one: UserAccount = constants.user_account_one
     user_two: UserAccount = constants.user_account_two
@@ -41,7 +40,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
             aut_two.attach()
             main_window.prepare()
             profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
-            chat_key = profile_popup.get_chat_key_from_profile_link
+            chat_key = profile_popup.copy_chat_key
             profile_popup.close()
             main_window.hide()
 
@@ -68,7 +67,7 @@ def test_group_chat(multiple_instance, user_data_one, user_data_two, user_data_t
             aut_three.attach()
             main_window.prepare()
             profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
-            chat_key = profile_popup.get_chat_key_from_profile_link
+            chat_key = profile_popup.copy_chat_key
             profile_popup.close()
             main_window.hide()
 


### PR DESCRIPTION
- Increased timeout in group chat test
- Changed a way we get chat key
- Enabled tests after bug fix for community links
- Edit channel didn't work yesterday (tried to find a reason, but no success), but today after fix it works just great!

CI runs for communities and messaging : 
- https://ci.status.im/job/status-desktop/job/e2e/job/manual/1300/