### PR TITLE
Chore/fix edit account and remove category tests

### DIFF
--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -332,9 +332,15 @@ class LeftPanel(QObject):
         driver.mouseClick(self.find_category_in_list(category_name).object)
 
     @allure.step('Open more options')
-    def open_more_options(self):
+    def open_more_options(self, attempts: int = 2):
         self._arrow_button.click()
-        self._more_button.click()
+        try:
+            self._more_button.click()
+        except LookupError as err:
+            if attempts:
+                return self._more_button.click(attempts - 1)
+            else:
+                raise err
         return self
 
     @allure.step('Get visibility state of delete item')

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
@@ -11,17 +11,19 @@ from gui.main_window import MainWindow
 from gui.screens.settings import SettingsScreen
 
 pytestmark = marks
+
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704433',
                  'Account view interactions: Edit Status default account')
 @pytest.mark.case(704433)
 @pytest.mark.parametrize('new_name', [
     pytest.param(''.join(random.choices(string.ascii_letters +
-                                        string.digits, k=40)))
+                                        string.digits, k=20)))
 ])
 def test_settings_edit_status_account(main_screen: MainWindow, new_name):
     with step('Open profile and wallet setting and check the keypairs list is not empty'):
-            settings = main_screen.left_panel.open_settings().left_panel.open_wallet_settings()
-            assert settings.get_keypairs_names !=0, f'Keypairs are not displayed'
+        settings = main_screen.left_panel.open_settings().left_panel.open_wallet_settings()
+        assert settings.get_keypairs_names != 0, f'Keypairs are not displayed'
 
     with step('Verify Status keypair title'):
         status_keypair_title = settings.get_keypairs_names()[0]


### PR DESCRIPTION
- Fix for edit status account test - https://github.com/status-im/status-desktop/pull/13414 here maximum was set to 20 symbols
- Added attempts for clicking more options button in remove category test

CI runs:
- https://ci.status.im/job/status-desktop/job/e2e/job/manual/1327/
- https://ci.status.im/job/status-desktop/job/e2e/job/manual/1326/

Allure reports:
<img width="1117" alt="Screenshot 2024-02-07 at 14 43 43" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/56d1a650-ad36-48af-9048-513f3c42acf7">

<img width="1117" alt="Screenshot 2024-02-07 at 14 36 40" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/74b8c879-d2e5-4fc9-8bfc-84b7b1861087">

