### PR TITLE
chore: categories and environment section added to allure report

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -164,9 +164,15 @@ pipeline {
       } } }
     }
   }
+
   post {
     always { script {
       archiveArtifacts('aut/*.log')
+
+      /* Needed to categorize types of errors and add environment section in allure report. */
+      sh 'cp ext/allure_files/categories.json allure-results'
+      sh 'cp ext/allure_files/environment.properties allure-results'
+
       allure([
         results: [[path: 'allure-results']],
         reportBuildPolicy: 'ALWAYS',

--- a/ext/allure_files/categories.json
+++ b/ext/allure_files/categories.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Skipped tests",
+    "matchedStatuses": ["skipped"] 
+  },
+  {
+    "name": "Lookup errors",
+    "messageRegex": ".*LookupError.*" 
+  },
+  {
+    "name": "Lost connection",
+    "messageRegex": ".*Lost connection to AUT.*" 
+  },
+    {
+    "name": "Connection refused",
+    "messageRegex": ".*connection to AUT refused.*"
+  },
+  {
+    "name": "Assertion errors",
+    "messageRegex": ".*AssertionError.*" 
+  }
+]

--- a/ext/allure_files/environment.properties
+++ b/ext/allure_files/environment.properties
@@ -1,0 +1,2 @@
+os_platform = linux
+python_version = Python 3.10


### PR DESCRIPTION
- Added categories for errors in Allure report. For now I defined these categories, @anastasiyaig if you have more ideas about popular errors, let me know I will add more 
- Also added environment section for our Allure report. I think in this section we can add useful info for those who doesn't really know a lot about our attests. It may help to understand the issue. So, the same here, @anastasiyaig  if you have ideas what else to put here - let me know

Example of CI run with changes:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1365/allure/

Allure report will look smth like this:
<img width="1106" alt="Screenshot 2024-02-12 at 14 10 40" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/e8903a63-393d-418a-8444-0e8d5841b7c1">

