### PR TITLE
chore: mark change password test as xfail again

### DIFF
--- a/gui/components/change_password_popup.py
+++ b/gui/components/change_password_popup.py
@@ -15,18 +15,17 @@ class ChangePasswordPopup(BasePopup):
         self._re_encrypt_data_restart_button = Button('reEncryptRestartButton')
         self._re_encryption_complete_element = TextLabel('reEncryptionComplete')
 
-    @allure.step('Wait for Sign out and quit button and click it')
     def click_re_encrypt_data_restart_button(self):
         """
-        Timeout is set as rough estimation of 15 seconds. What is happening when changing password is
+        Timeout is set as rough estimation of 20 seconds. What is happening when changing password is
         the process of re-hashing DB initiated. Taking into account the user is new , so DB is relatively small
-        I assume, 15 seconds should be enough to finish re-hashing and show the Restart button
+        I assume, 20 seconds should be enough to finish re-hashing and show the Restart button
         This time is not really predictable, especially for huge DBs.
         """
         self._re_encrypt_data_restart_button.click()
         assert driver.waitForObject(self._re_encryption_complete_element.real_name, 15000), \
             f'Re-encryption confirmation is not present within 15 seconds'
-        assert driver.waitForObject(self._re_encrypt_data_restart_button.real_name, 17000)
+        assert driver.waitForObject(self._re_encrypt_data_restart_button.real_name, 20000)
         assert getattr(self._re_encrypt_data_restart_button.object, 'text') == PasswordView.RESTART_STATUS.value
         self._re_encrypt_data_restart_button.click()
 

--- a/tests/settings/settings_password/test_settings_password_change_password.py
+++ b/tests/settings/settings_password/test_settings_password_change_password.py
@@ -21,7 +21,7 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
-#@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13013')
+@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13013')
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings'):
         settings_scr = main_screen.left_panel.open_settings()
@@ -32,7 +32,7 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
     with step('Fill in the change password form and submit'):
         password_view.change_password(user_account.password, user_account_changed_password.password)
 
-    with step('Re-encrypt'):
+    with step('Click re-encrypt data button and then restart'):
         ChangePasswordPopup().click_re_encrypt_data_restart_button()
 
     with step('Verify the application process is not running'):


### PR DESCRIPTION
I noticed that the problem with slow rehasing is still there https://github.com/status-im/status-desktop/issues/13013

And it fails the critical path now in some PRs