### PR TITLE
test: updated permission test with editing and deleting

### DIFF
--- a/constants/community_settings.py
+++ b/constants/community_settings.py
@@ -31,3 +31,5 @@ class AirdropsElements(Enum):
 
 class ToastMessages(Enum):
     CREATE_PERMISSION_TOAST = 'Community permission created'
+    UPDATE_PERMISSION_TOAST = 'Community permission updated'
+    DELETE_PERMISSION_TOAST = 'Community permission updated'

--- a/gui/components/changes_detected_popup.py
+++ b/gui/components/changes_detected_popup.py
@@ -16,3 +16,15 @@ class ChangesDetectedToastMessage(QObject):
     def save(self):
         self._save_button.click()
         self.wait_until_hidden()
+
+
+class PermissionsChangesDetectedToastMessage(QObject):
+
+    def __init__(self):
+        super().__init__(names.editPermissionView_settingsDirtyToastMessage_SettingsDirtyToastMessage)
+        self._update_permission_button = Button(names.editPermissionView_Save_changes_StatusButton)
+
+    @allure.step('Update permission')
+    def update_permission(self):
+        self._update_permission_button.click()
+        self.wait_until_hidden()

--- a/gui/components/delete_popup.py
+++ b/gui/components/delete_popup.py
@@ -22,10 +22,15 @@ class DeletePopup(BasePopup):
                 raise ex
 
 
-
-
 class DeleteCategoryPopup(DeletePopup):
 
     def __init__(self):
         super().__init__()
         self._delete_button = Button(names.confirm_StatusButton)
+
+
+class DeletePermissionPopup(DeletePopup):
+
+    def __init__(self):
+        super().__init__()
+        self._delete_button = Button(names.confirm_permission_delete_StatusButton)

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -230,6 +230,7 @@ mainWallet_AddEditAccountPopup_AccountEmoji = {"container": statusDesktop_mainWi
 o_StatusDialogBackground = {"container": statusDesktop_mainWindow_overlay, "type": "StatusDialogBackground", "unnamed": 1, "visible": True}
 delete_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "deleteChatConfirmationDialogDeleteButton", "type": "StatusButton", "visible": True}
 confirm_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "confirmDeleteCategoryButton", "type": "StatusButton", "visible": True}
+confirm_permission_delete_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "id": "confirmButton", "type": "StatusButton", "unnamed": 1, "visible": True}
 
 # Authenticate Popup
 keycardSharedPopupContent_KeycardPopupContent = {"container": statusDesktop_mainWindow_overlay, "objectName": "KeycardSharedPopupContent", "type": "KeycardPopupContent", "visible": True}
@@ -727,6 +728,12 @@ mainWindow_PermissionsSettingsPanel = {"container": statusDesktop_mainWindow, "t
 whoHoldsTagListItem = {"container": mainWindow_PermissionsView, "objectName": "whoHoldsStatusListItem", "type": "StatusListItemTag", "visible": True}
 isAllowedTagListItem = {"container": mainWindow_PermissionsView, "objectName": "isAllowedStatusListItem", "type": "StatusListItemTag", "visible": True}
 inCommunityTagListItem = {"container": mainWindow_PermissionsView, "objectName": "inCommunityStatusListItem", "type": "StatusListItemTag", "visible": True}
+edit_pencil_icon_StatusIcon = {"container": mainWindow_PermissionsView, "objectName": "edit_pencil-icon", "type": "StatusIcon", "visible": True}
+delete_icon_StatusIcon = {"container": mainWindow_PermissionsView, "objectName": "delete-icon", "type": "StatusIcon", "visible": True}
+hide_icon_StatusIcon = {"container": mainWindow_PermissionsView, "objectName": "hide-icon", "type": "StatusIcon", "visible": True}
+editPermissionView_settingsDirtyToastMessage_SettingsDirtyToastMessage = {"container": mainWindow_editPermissionView_EditPermissionView, "id": "settingsDirtyToastMessage", "type": "SettingsDirtyToastMessage", "unnamed": 1, "visible": True}
+update_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+isAllowedToEditPermissionView_StatusListItemTag = {"container": mainWindow_editPermissionView_EditPermissionView, "type": "StatusListItemTag", "unnamed": 1, "visible": True}
 
 # Edit Community
 mainWindow_communityEditPanelScrollView_EditSettingsPanel = {"container": statusDesktop_mainWindow, "objectName": "communityEditPanelScrollView", "type": "EditSettingsPanel", "visible": True}
@@ -750,6 +757,7 @@ communityEditPanelScrollView_pinMessagesToggle_StatusCheckBox = {"checkable": Tr
 communityEditPanelScrollView_editCommunityIntroInput_TextEdit = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCommunityIntroInput", "type": "TextEdit", "visible": True}
 communityEditPanelScrollView_editCommunityOutroInput_TextEdit = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCommunityOutroInput", "type": "TextEdit", "visible": True}
 mainWindow_Save_changes_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
+editPermissionView_Save_changes_StatusButton = {"container": mainWindow_editPermissionView_EditPermissionView, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
 croppedImageEditLogo = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCroppedImageItem_Community logo", "type": "EditCroppedImagePanel", "visible": True}
 croppedImageEditBanner = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCroppedImageItem_Community banner", "type": "EditCroppedImagePanel", "visible": True}
 

--- a/gui/screens/community_settings.py
+++ b/gui/screens/community_settings.py
@@ -450,20 +450,37 @@ class PermissionsSettingsView(QObject):
         self._is_allowed_to_edit_tag = QObject(names.isAllowedToEditPermissionView_StatusListItemTag)
 
     @allure.step('Get titles of Who holds tags')
-    def get_who_holds_tags_titles(self) -> typing.List[str]:
-        who_holds_tags = [str(tag.title) for tag in driver.findAllObjects(self._who_holds_tag.real_name)]
-        return who_holds_tags
+    def get_who_holds_tags_titles(self, attempt: int = 2) -> typing.List[str]:
+        try:
+            return [str(tag.title) for tag in driver.findAllObjects(self._who_holds_tag.real_name)]
+        except AttributeError as er:
+            if attempt:
+                time.sleep(1)
+                return self.get_who_holds_tags_titles(attempt - 1)
+            else:
+                raise er
 
     @allure.step('Get titles of Is Allowed tags')
-    def get_is_allowed_tags_titles(self) -> typing.List[str]:
-        is_allowed_tags = [str(tag.title) for tag in driver.findAllObjects(self._is_allowed_tag.real_name)]
-        return is_allowed_tags
+    def get_is_allowed_tags_titles(self, attempt: int = 2) -> typing.List[str]:
+        try:
+            return [str(tag.title) for tag in driver.findAllObjects(self._is_allowed_tag.real_name)]
+        except AttributeError as er:
+            if attempt:
+                time.sleep(1)
+                return self.get_is_allowed_tags_titles(attempt - 1)
+            else:
+                raise er
 
     @allure.step('Get title of inCommunity tag')
-    def get_in_community_in_channel_tags_titles(self) -> typing.List[str]:
-        in_community_in_channel_tags = [str(tag.title) for tag in
-                                        driver.findAllObjects(self._in_community_in_channel_tag.real_name)]
-        return in_community_in_channel_tags
+    def get_in_community_in_channel_tags_titles(self, attempt: int = 2) -> typing.List[str]:
+        try:
+            return [str(tag.title) for tag in driver.findAllObjects(self._in_community_in_channel_tag.real_name)]
+        except AttributeError as er:
+            if attempt:
+                time.sleep(1)
+                return self.get_in_community_in_channel_tags_titles(attempt - 1)
+            else:
+                raise er
 
     @allure.step('Set state of who holds checkbox')
     def set_who_holds_checkbox_state(self, state):

--- a/tests/communities/test_communities_permissions.py
+++ b/tests/communities/test_communities_permissions.py
@@ -2,6 +2,7 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+import configs
 from gui.components.changes_detected_popup import PermissionsChangesDetectedToastMessage
 from gui.components.delete_popup import DeletePermissionPopup
 from gui.components.toast_message import ToastMessage
@@ -62,16 +63,21 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
 
     with step('Created permission is displayed on permission page'):
         if asset_title is not False:
-            assert driver.waitFor(lambda: asset_title in permissions_settings.get_who_holds_tags_titles())
+            assert driver.waitFor(lambda: asset_title in permissions_settings.get_who_holds_tags_titles(),
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         if second_asset_title is not False:
-            assert driver.waitFor(lambda: second_asset_title in permissions_settings.get_who_holds_tags_titles())
+            assert driver.waitFor(lambda: second_asset_title in permissions_settings.get_who_holds_tags_titles(),
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         if allowed_to_title is not False:
-            assert driver.waitFor(lambda: allowed_to_title in permissions_settings.get_is_allowed_tags_titles())
+            assert driver.waitFor(lambda: allowed_to_title in permissions_settings.get_is_allowed_tags_titles(),
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         if in_channel is False:
             assert driver.waitFor(
-                lambda: params['name'] in permissions_settings.get_in_community_in_channel_tags_titles())
+                lambda: params['name'] in permissions_settings.get_in_community_in_channel_tags_titles(),
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         if in_channel:
-            assert driver.waitFor(lambda: in_channel in permissions_settings.get_in_community_in_channel_tags_titles())
+            assert driver.waitFor(lambda: in_channel in permissions_settings.get_in_community_in_channel_tags_titles(),
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     with step('Edit permission'):
         edit_permission_view = permissions_intro_view.open_edit_permission_view()
@@ -88,14 +94,14 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
         changes_popup.update_permission()
         if allowed_to is 'becomeAdmin' and checkbox_state is True:
             if asset_title is not False:
-                assert driver.waitFor(lambda: asset_title not in permissions_settings.get_who_holds_tags_titles())
+                assert driver.waitFor(lambda: asset_title not in permissions_settings.get_who_holds_tags_titles(), configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
             if second_asset_title is not False:
                 assert driver.waitFor(
-                    lambda: second_asset_title not in permissions_settings.get_who_holds_tags_titles())
+                    lambda: second_asset_title not in permissions_settings.get_who_holds_tags_titles(), configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         elif checkbox_state is False:
-            assert driver.waitFor(lambda: 'Become member' in permissions_settings.get_is_allowed_tags_titles())
+            assert driver.waitFor(lambda: 'Become member' in permissions_settings.get_is_allowed_tags_titles(), configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         else:
-            assert driver.waitFor(lambda: permissions_intro_view.is_hide_icon_visible)
+            assert driver.waitFor(lambda: permissions_intro_view.is_hide_icon_visible, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     with step('Check toast message for edited permission'):
         messages = ToastMessage().get_toast_messages

--- a/tests/communities/test_communities_permissions.py
+++ b/tests/communities/test_communities_permissions.py
@@ -19,7 +19,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703632',
                  'Manage community: Adding new permissions, Editing permissions, Deleting permission')
-@pytest.mark.case(703632, 703162, 705016)
+@pytest.mark.case(703632, 705014, 705016)
 @pytest.mark.parametrize('params', [constants.community_params])
 @pytest.mark.parametrize(
     'checkbox_state, first_asset, second_asset, amount, allowed_to, in_channel, asset_title, second_asset_title, '

--- a/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -5,7 +5,7 @@ from . import marks
 
 import constants
 from driver.aut import AUT
-from gui.components.settings.changes_detected_popup import ChangesDetectedToastMessage
+from gui.components.changes_detected_popup import ChangesDetectedToastMessage
 from gui.main_window import MainWindow
 
 pytestmark = marks


### PR DESCRIPTION
Permissions test has been updated. I added 3 separate test cases (creating, editing and deleting) and we will just report to all 3. Added critical mark to 2 of parameters.

I also tried to fix Attribute error by refactoring methods where the error occur. Let's see if it helped. 

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1429/

<img width="1110" alt="Screenshot 2024-02-16 at 12 10 04" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/4bee3c3c-56e7-4ba5-b1c3-fed5f83ef1ff">

