### PR TITLE
chore: replace file upload dialog usage

### DIFF
--- a/gui/components/community/create_community_popups.py
+++ b/gui/components/community/create_community_popups.py
@@ -90,7 +90,7 @@ class CreateCommunityPopup(BasePopup):
     @allure.step('Set community logo')
     def logo(self, kwargs: dict):
         self._open_logo_file_dialog().open_file(kwargs['fp'])
-        PictureEditPopup().wait_until_appears().make_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
+        PictureEditPopup().wait_until_appears().set_zoom_shift_for_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
 
     @property
     @allure.step('Get community banner')
@@ -101,7 +101,7 @@ class CreateCommunityPopup(BasePopup):
     def banner(self, kwargs: dict):
         self._add_banner_button.click()
         OpenFileDialog().wait_until_appears().open_file(kwargs['fp'])
-        PictureEditPopup().wait_until_appears().make_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
+        PictureEditPopup().wait_until_appears().set_zoom_shift_for_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
 
     @allure.step('Set community logo without file upload dialog')
     def set_logo_without_file_upload_dialog(self, path):
@@ -164,9 +164,9 @@ class CreateCommunityPopup(BasePopup):
     @allure.step('Create community without file upload dialog usage')
     def create_community(self, kwargs):
         self.set_logo_without_file_upload_dialog(kwargs['logo']['fp'])
-        PictureEditPopup().make_picture(None, None)
+        PictureEditPopup().set_zoom_shift_for_picture(None, None)
         self.set_banner_without_file_upload_dialog(kwargs['banner']['fp'])
-        PictureEditPopup().make_picture(None, None)
+        PictureEditPopup().set_zoom_shift_for_picture(None, None)
         for key in list(kwargs):
             if key in ['intro', 'outro'] and self._next_button.is_visible:
                 self._next_button.click()

--- a/gui/components/picture_edit_popup.py
+++ b/gui/components/picture_edit_popup.py
@@ -23,7 +23,7 @@ class PictureEditPopup(BasePopup):
         self._slider_handler = QObject(names.o_DropShadow)
 
     @allure.step('Make picture')
-    def make_picture(
+    def set_zoom_shift_for_picture(
             self,
             zoom: int = None,
             shift: shift_image = None

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -906,7 +906,7 @@ mainWindow_insertDetailsViewChatKeyTxt_StyledText = {"container": mainWindow_Ins
 mainWindow_EmojiHash = {"container": statusDesktop_mainWindow, "objectName": "publicKeyEmojiHash", "type": "EmojiHash", "visible": True}
 mainWindow_Header_Title = {"container": statusDesktop_mainWindow, "objectName": "onboardingHeaderText", "type": "StyledText", "visible": True}
 mainWindow_userImageCopy_StatusSmartIdenticon = {"container": mainWindow_InsertDetailsView, "id": "userImageCopy", "type": "StatusSmartIdenticon", "unnamed": 1, "visible": True}
-
+profileImageCropper = {"container": statusDesktop_mainWindow, "objectName": "imageCropWorkflow", "type": "ImageCropWorkflow", "visible": True}
 
 # Create Password View
 mainWindow_CreatePasswordView = {"container": statusDesktop_mainWindow, "type": "CreatePasswordView", "unnamed": 1, "visible": True}

--- a/gui/screens/community_settings.py
+++ b/gui/screens/community_settings.py
@@ -152,7 +152,7 @@ class EditCommunityView(QObject):
     def logo(self, kwargs: dict):
         self._add_logo_button.click()
         OpenFileDialog().wait_until_appears().open_file(kwargs['fp'])
-        PictureEditPopup().wait_until_appears().make_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
+        PictureEditPopup().wait_until_appears().set_zoom_shift_for_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
 
     @property
     @allure.step('Get community banner')
@@ -163,7 +163,7 @@ class EditCommunityView(QObject):
     def banner(self, kwargs: dict):
         self._add_banner_button.click()
         OpenFileDialog().wait_until_appears().open_file(kwargs['fp'])
-        PictureEditPopup().wait_until_appears().make_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
+        PictureEditPopup().wait_until_appears().set_zoom_shift_for_picture(kwargs.get('zoom', None), kwargs.get('shift', None))
 
     @allure.step('Set community logo without file upload dialog')
     def set_logo_without_file_upload_dialog(self, path):
@@ -233,9 +233,9 @@ class EditCommunityView(QObject):
     @allure.step('Edit community')
     def edit(self, kwargs):
         self.set_logo_without_file_upload_dialog(kwargs['logo']['fp'])
-        PictureEditPopup().make_picture(None, None)
+        PictureEditPopup().set_zoom_shift_for_picture(None, None)
         self.set_banner_without_file_upload_dialog(kwargs['banner']['fp'])
-        PictureEditPopup().make_picture(None, None)
+        PictureEditPopup().set_zoom_shift_for_picture(None, None)
         for key in list(kwargs):
             setattr(self, key, kwargs.get(key))
         self._save_changes_button.click()

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -268,6 +268,7 @@ class YourProfileView(OnboardingView):
         self._clear_icon = QObject(names.mainWindow_clear_icon_StatusIcon)
         self._identicon_ring = QObject(names.mainWindow_IdenticonRing)
         self._view_header_title = TextLabel(names.mainWindow_Header_Title)
+        self._image_crop_workflow = QObject(names.profileImageCropper)
 
     def verify_profile_view_present(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
         driver.waitFor(lambda: self._view_header_title.exists, timeout_msec)
@@ -311,7 +312,13 @@ class YourProfileView(OnboardingView):
         self._clear_icon.click()
         return self
 
-    @allure.step('Set user image')
+    @allure.step('Set profile picture without file upload dialog')
+    def set_profile_picture(self, path) -> PictureEditPopup:
+        image_cropper = driver.waitForObjectExists(self._image_crop_workflow.real_name)
+        image_cropper.cropImage(('file://' + str(path)))
+        return PictureEditPopup()
+
+    @allure.step('Set profile picture with file dialog upload')
     def set_user_image(self, fp: SystemPath) -> PictureEditPopup:
         allure.attach(name='User image', body=fp.read_bytes(), attachment_type=allure.attachment_type.PNG)
         self._upload_picture_button.hover()

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -10,7 +10,7 @@ from . import marks
 import configs.timeouts
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.picture_edit_popup import shift_image
+from gui.components.picture_edit_popup import shift_image, PictureEditPopup
 from gui.components.splash_screen import SplashScreen
 from gui.screens.onboarding import AllowNotificationsView, WelcomeToStatusView, BiometricsView, KeysView
 
@@ -29,7 +29,7 @@ def keys_screen(main_window) -> KeysView:
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703421', 'Generate new keys')
 @pytest.mark.case(703421)
-# @pytest.mark.critical TODO: https://github.com/status-im/status-desktop/issues/13483
+@pytest.mark.critical
 @pytest.mark.parametrize('user_name, password, user_image, zoom, shift', [
     pytest.param(
         ''.join((random.choice(
@@ -59,9 +59,8 @@ def test_generate_new_keys(main_window, keys_screen, user_name: str, password, u
             f'Error message {profile_view.get_error_message} is present when it should not'
 
     with step('Click plus button and add user picture'):
-        if user_image is not None:
-            profile_picture_popup = profile_view.set_user_image(configs.testpath.TEST_IMAGES / user_image)
-            profile_picture_popup.make_picture(zoom=zoom, shift=shift)
+        profile_view.set_profile_picture(configs.testpath.TEST_IMAGES / user_image)
+        PictureEditPopup().set_zoom_shift_for_picture(zoom=zoom, shift=shift)
         # TODO: find a way to verify the picture is there (changed to the custom one)
         assert profile_view.get_profile_image is not None, f'Profile picture was not set / applied'
         assert profile_view.is_identicon_ring_visible, f'Identicon ring is not present when it should'

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -17,6 +17,7 @@ from gui.screens.onboarding import BiometricsView, AllowNotificationsView, Welco
 
 pytestmark = marks
 
+
 @pytest.fixture
 def keys_screen(main_window) -> KeysView:
     with step('Open Generate new keys view'):
@@ -63,4 +64,3 @@ def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, au
         user_canvas = main_window.left_panel.open_online_identifier()
         profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
-        

--- a/tests/settings/settings_password/test_settings_password_change_password.py
+++ b/tests/settings/settings_password/test_settings_password_change_password.py
@@ -14,14 +14,14 @@ pytestmark = marks
 
 
 @pytest.mark.timeout(timeout=180)
-@pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')
 @pytest.mark.case(703005)
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/13013')
+@pytest.mark.flaky
+# reason='https://github.com/status-im/status-desktop/issues/13013'
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings'):
         settings_scr = main_screen.left_panel.open_settings()

--- a/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -9,6 +9,8 @@ from gui.components.settings.changes_detected_popup import ChangesDetectedToastM
 from gui.main_window import MainWindow
 
 pytestmark = marks
+
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703006',
                  'Set display name, bio and social links')
 @pytest.mark.case(703006)

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_add_account_after_restart.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_add_account_after_restart.py
@@ -25,6 +25,7 @@ pytestmark = marks
                          [
                              pytest.param('GenAcc2', '#2a4af5', 'sunglasses', '1f60e')
                          ])
+@pytest.mark.critical
 def test_add_generated_account_restart_add_again(
         aut: AUT, main_screen: MainWindow, user_account,
         color: str, emoji: str, emoji_unicode: str, name: str,


### PR DESCRIPTION
Onboarding tests on linux 03: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1418/allure/
Critical path run on linux 03: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1423/allure/
Full run on Linux 03: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1425/allure/#suites/c48b221cdcfecf89e1eb75d0b8e79672/4859437cf715a99b/

<img width="1840" alt="Screenshot 2024-02-15 at 18 41 50" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/f1354432-dd84-41d3-9856-56e742fea10d">
