### PR TITLE
Chore/fix nightly run fails

### DIFF
--- a/gui/objects_map/communities_names.py
+++ b/gui/objects_map/communities_names.py
@@ -160,7 +160,6 @@ communityEditPanelScrollView_requestToJoinToggle_StatusCheckBox = {"checkable": 
 communityEditPanelScrollView_pinMessagesToggle_StatusCheckBox = {"checkable": True, "container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "id": "pinMessagesToggle", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
 communityEditPanelScrollView_editCommunityIntroInput_TextEdit = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCommunityIntroInput", "type": "TextEdit", "visible": True}
 communityEditPanelScrollView_editCommunityOutroInput_TextEdit = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCommunityOutroInput", "type": "TextEdit", "visible": True}
-mainWindow_Save_changes_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
 editPermissionView_Save_changes_StatusButton = {"container": mainWindow_editPermissionView_EditPermissionView, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
 croppedImageEditLogo = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCroppedImageItem_Community logo", "type": "EditCroppedImagePanel", "visible": True}
 croppedImageEditBanner = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCroppedImageItem_Community banner", "type": "EditCroppedImagePanel", "visible": True}

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -9,6 +9,7 @@ statusDesktop_mainWindow_overlay_popup2 = {"container": statusDesktop_mainWindow
 scrollView_StatusScrollView = {"container": statusDesktop_mainWindow_overlay, "id": "scrollView", "type": "StatusScrollView", "unnamed": 1, "visible": True}
 splashScreen = {"container": statusDesktop_mainWindow, "objectName": "splashScreen", "type": "DidYouKnowSplashScreen"}
 settingsSave_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
+mainWindow_Save_changes_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
 
 # Main right panel
 mainWindow_RighPanel = {"container": statusDesktop_mainWindow, "type": "ColumnLayout", "objectName": "mainRightView", "visible": True}

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -84,7 +84,7 @@ def test_sync_device_during_onboarding(multiple_instance, user_data):
                 raise ex
             sync_result = SyncResultView()
             assert driver.waitFor(
-                lambda: 'Device synced!' in sync_result.device_synced_notifications, 15000)
+                lambda: 'Device synced!' in sync_result.device_synced_notifications, 18000)
             assert user.name in sync_device_found.device_found_notifications
 
         with step('Sign in to synced account'):


### PR DESCRIPTION
- Fixed locator for failed tests (online_identifier, set_own_display_name and set_name_bio_social_links)
- Increased timeout a bit for syncing device test

Runs:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1480/
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1481/
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1482/