### PR TITLE
Add more logs to the aut instance

### DIFF
--- a/driver/aut.py
+++ b/driver/aut.py
@@ -112,6 +112,7 @@ class AUT:
         self.port = local_system.find_free_port(configs.squish.AUT_PORT, 100)
         command = [
             str(configs.testpath.SQUISH_DIR / 'bin/startaut'),
+            '--verbose',
             f'--port={self.port}',
             str(self.path),
             f'-d={self.app_data}',


### PR DESCRIPTION
trying to grab more logs in aut.py file to culprit the issue with connection refused error

run 1: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1493/console
run 2: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1497/console