### PR TITLE
chore: remove flaky mark from change password test

### DIFF
--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -33,7 +33,7 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 @pytest.mark.parametrize('autocomplete', [
     pytest.param(False),
-    pytest.param(True)
+    pytest.param(True, marks=pytest.mark.critical)
 ])
 def test_import_seed_phrase(aut: AUT, keys_screen, main_window, user_account, autocomplete: bool):
     with step('Open import seed phrase view and enter seed phrase'):

--- a/tests/settings/settings_password/test_settings_password_change_password.py
+++ b/tests/settings/settings_password/test_settings_password_change_password.py
@@ -20,8 +20,8 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed_password',
                          [pytest.param(constants.user.user_account_one,
                                        constants.user.user_account_one_changed_password)])
-@pytest.mark.flaky
-# reason='https://github.com/status-im/status-desktop/issues/13013'
+@pytest.mark.critical
+# TODO: follow up on https://github.com/status-im/status-desktop/issues/13013
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
     with step('Open profile settings'):
         settings_scr = main_screen.left_panel.open_settings()
@@ -36,7 +36,7 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         ChangePasswordPopup().click_re_encrypt_data_restart_button()
 
     with step('Verify the application process is not running'):
-        psutil.Process(aut.pid).wait(timeout=10)
+        psutil.Process(aut.pid).wait(timeout=30)
 
     with step('Restart application'):
         aut.restart()


### PR DESCRIPTION
- removed the flaky mark from change password test
- increased timeout for 30 seconds just now (i communicated that to be enough)

We need this test to show actual result , because we missed https://github.com/status-im/status-desktop/issues/13748 because of this

~**TODO:** enable this test back to critical path when bug is fixed. This test will now fail in master~