### PR TITLE
Implement reruns functionality and fix data directory parameter

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -151,9 +151,9 @@ pipeline {
               passwordVariable: 'TESTRAIL_PSW'
             )
           ]) {
+            /* Keep the --reruns flag first, or it won't work */
             sh """
-              python3 -m pytest ${flags.join(" ")} \
-                --ignore-flaky \
+              python3 -m pytest --reruns=1 ${flags.join(" ")} \
                 --disable-warnings \
                 --alluredir=./allure-results
             """

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -115,7 +115,7 @@ class AUT:
             '--verbose',
             f'--port={self.port}',
             str(self.path),
-            f'-d={self.app_data}',
+            f'--datadir={self.app_data}',
             f'--LOG_LEVEL={configs.testpath.LOG_LEVEL}',
         ]
         try:

--- a/gui/components/change_password_popup.py
+++ b/gui/components/change_password_popup.py
@@ -17,10 +17,11 @@ class ChangePasswordPopup(BasePopup):
 
     def click_re_encrypt_data_restart_button(self):
         """
-        Timeout is set as rough estimation of 20 seconds. What is happening when changing password is
+        Timeout is set as rough estimation of 30 seconds. What is happening when changing password is
         the process of re-hashing DB initiated. Taking into account the user is new , so DB is relatively small
-        I assume, 20 seconds should be enough to finish re-hashing and show the Restart button
+        I assume, 30 seconds should be enough to finish re-hashing and show the Restart button
         This time is not really predictable, especially for huge DBs.
+        In case it does not please check https://github.com/status-im/status-desktop/issues/13013 for context
         """
         self._re_encrypt_data_restart_button.click()
         assert driver.waitForObject(self._re_encryption_complete_element.real_name, 30000), \

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ log_cli = true
 log_cli_level = INFO
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)7s CLI %(name)s  %(message).5000s
 
-addopts = --disable-warnings -p no:logging
+addopts = --reruns=1 --disable-warnings -p no:logging
 
 markers =
     critical: Critical checks for every PR

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ atomacos==3.3.0; platform_system == "Darwin"
 allure-pytest==2.13.2
 testrail-api==1.12.0
 pyperclip==1.8.2
-pytest-rerunfailures==11.1.2
+pytest-rerunfailures==13.0
 pytest-ignore-flaky==2.1.0
 pytest-timeout==2.2.0

--- a/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -32,7 +32,6 @@ def keys_screen(main_window) -> KeysView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703010', 'Settings - Sign out & Quit')
 @pytest.mark.case(703421, 703010)
 @pytest.mark.critical
-@pytest.mark.flaky
 # reason='https://github.com/status-im/status-desktop/issues/13013'
 @pytest.mark.parametrize('user_name, password, user_image, zoom, shift', [
     pytest.param(


### PR DESCRIPTION
Partially addresses https://github.com/status-im/desktop-qa-automation/issues/558
- replace `-d` with correct `-datadir`
- add rerun attempt for failed tests
- some small changes on the go