### PR TITLE
chore: clean up in context.py

### DIFF
--- a/driver/aut.py
+++ b/driver/aut.py
@@ -81,27 +81,19 @@ class AUT:
         self.pid = None
 
     @allure.step('Attach Squish to Test Application')
-    def attach(self):
+    def attach(self, timeout_sec: int = configs.timeouts.PROCESS_TIMEOUT_SEC):
         LOG.info('Attaching to AUT: localhost:%d', self.port)
-        for i in range(3):
-            try:
-                SquishServer().add_attachable_aut(self.aut_id, self.port)
-                if self.ctx is None:
-                    self.ctx = context.get_context(self.aut_id)
-                else:
-                    if self.ctx is None:
-                        for j in range(3):
-                            try:
-                                context.get_context(self.aut_id)
-                            except AttributeError:
-                                continue
 
-                squish.setApplicationContext(self.ctx)
-                assert squish.waitFor(lambda: self.ctx.isRunning, configs.timeouts.PROCESS_TIMEOUT_SEC)
-            except Exception as err:
-                LOG.error('Failed to attach AUT: %s', err)
-                self.stop()
-                raise err
+        try:
+            SquishServer().add_attachable_aut(self.aut_id, self.port)
+            if self.ctx is None:
+                self.ctx = context.get_context(self.aut_id)
+            squish.setApplicationContext(self.ctx)
+            assert squish.waitFor(lambda: self.ctx.isRunning, configs.timeouts.PROCESS_TIMEOUT_SEC)
+        except Exception as err:
+            LOG.error('Failed to attach AUT: %s', err)
+            self.stop()
+            raise err
         LOG.info('Successfully attached AUT!')
         return self
 
@@ -141,7 +133,7 @@ class AUT:
         return self
 
     @allure.step('Waiting for port')
-    def wait(self, timeout: int = 3, retries: int = 10):
+    def wait(self, timeout: int = 1, retries: int = 10):
         LOG.info('Waiting for AUT port localhost:%d...', self.port)
         try:
             wait_for_port('localhost', self.port, timeout, retries)

--- a/driver/context.py
+++ b/driver/context.py
@@ -12,16 +12,15 @@ LOG = logging.getLogger(__name__)
 
 @allure.step('Get application context of "{0}"')
 def get_context(aut_id: str):
-    for i in range(10):
-        try:
-            LOG.debug('Attaching to: %s', aut_id)
-            context = squish.attachToApplication(aut_id, SquishServer().host, SquishServer().port)
-            if context is not None:
-                LOG.info('AUT %s context found', aut_id)
-                return context
-        except RuntimeError:
-            time.sleep(10)
-            continue
+    LOG.info('Attaching to: %s', aut_id)
+    try:
+        context = squish.attachToApplication(aut_id, SquishServer().host, SquishServer().port)
+        if context is not None:
+            LOG.info('AUT %s context found', aut_id)
+            return context
+    except RuntimeError as error:
+        LOG.error('AUT %s context has not been found', aut_id)
+        raise error
 
 
 @allure.step('Detaching')


### PR DESCRIPTION
Removed unnecessary code that was added before. The code is not really working and the real reason for context being invalid (not found , none) is that the application crashes from time to time and we dont really handle that with Squish logic. Current workaround is if test failed - retry it 1 time. So no inner loops are needed and they are useless anyway