### PR TITLE
chore: do not remove log files for local runs and improve the folder namings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 
 *.DS_Store
 
+/local run results/

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ tmp/
 
 *.DS_Store
 
-/local run results/
+/local_run_results/

--- a/configs/testpath.py
+++ b/configs/testpath.py
@@ -12,9 +12,8 @@ TEST_VP: typing.Optional[SystemPath] = None
 TEST_ARTIFACTS: typing.Optional[SystemPath] = None
 
 # Test Directories
-RUN_ID = os.getenv('RUN_DIR', f'run_{datetime.now():%d%m%Y_%H%M%S}')
-TEMP: SystemPath = ROOT / 'tmp'
-RESULTS: SystemPath = TEMP / 'results'
+RUN_ID = os.getenv('RUN_DIR', f'run_{datetime.today().strftime("%Y-%m-%d %H:%M:%S")}')
+RESULTS: SystemPath = ROOT / 'local run results'
 RUN: SystemPath = RESULTS / RUN_ID
 VP: SystemPath = ROOT / 'ext' / 'vp'
 TEST_FILES: SystemPath = ROOT / 'ext' / 'test_files'

--- a/configs/testpath.py
+++ b/configs/testpath.py
@@ -13,7 +13,7 @@ TEST_ARTIFACTS: typing.Optional[SystemPath] = None
 
 # Test Directories
 RUN_ID = os.getenv('RUN_DIR', f'run_{datetime.today().strftime("%Y-%m-%d %H:%M:%S")}')
-RESULTS: SystemPath = ROOT / 'local run results'
+RESULTS: SystemPath = ROOT / 'local_run_results'
 RUN: SystemPath = RESULTS / RUN_ID
 VP: SystemPath = ROOT / 'ext' / 'vp'
 TEST_FILES: SystemPath = ROOT / 'ext' / 'test_files'

--- a/configs/testpath.py
+++ b/configs/testpath.py
@@ -27,7 +27,7 @@ assert SQUISH_DIR_RAW is not None
 SQUISH_DIR = SystemPath(SQUISH_DIR_RAW)
 
 # Status Application
-STATUS_DATA: SystemPath = RUN / 'status'
+STATUS_DATA: SystemPath = RUN
 
 # Sets log level, can be one of: "ERROR", "WARN", "INFO", "DEBUG", "TRACE". "INFO"
 LOG_LEVEL = 'DEBUG'

--- a/conftest.py
+++ b/conftest.py
@@ -42,11 +42,10 @@ def setup_session_scope(
 def setup_function_scope(
         caplog,
         generate_test_data,
-        check_result,
-        application_logs
+        check_result
 ):
     # FIXME: broken due to KeyError: <_pytest.stash.StashKey object at 0x7fd1ba6d78c0>
-    #caplog.set_level(configs.LOG_LEVEL)
+    # caplog.set_level(configs.LOG_LEVEL)
     yield
 
 
@@ -61,10 +60,7 @@ def pytest_exception_interact(node):
     test_path, test_name, test_params = generate_test_info(node)
     node_dir: SystemPath = configs.testpath.RUN / test_path / test_name / test_params
     node_dir.mkdir(parents=True, exist_ok=True)
-
-    screenshot = node_dir / 'screenshot.png'
-    if screenshot.exists():
-        screenshot = node_dir / f'screenshot_{datetime.now():%H%M%S}.png'
+    screenshot = node_dir / f'screenshot_{datetime.today().strftime("%Y-%m-%d %H:%M:%S")}.png'
     ImageGrab.grab(xdisplay=configs.system.DISPLAY if IS_LIN else None).save(screenshot)
     allure.attach(
         name='Screenshot on fail',

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -64,7 +64,7 @@ class AUT:
                     body=screenshot.read_bytes(),
                     attachment_type=allure.attachment_type.PNG)
             except Exception as err:
-                LOG.info(err)
+                LOG.error(err)
 
         self.stop()
 

--- a/driver/aut.py
+++ b/driver/aut.py
@@ -7,7 +7,7 @@ from PIL import ImageGrab
 
 import configs
 import driver
-from os import path
+import shortuuid
 from datetime import datetime
 from configs.system import IS_LIN
 from driver import context
@@ -32,7 +32,7 @@ class AUT:
         self.pid = None
         self.port = None
         self.aut_id = f'AUT_{datetime.now():%H%M%S}'
-        self.app_data = configs.testpath.STATUS_DATA / f'app_{datetime.now():%H%M%S_%f}'
+        self.app_data = configs.testpath.STATUS_DATA / f'app_{shortuuid.ShortUUID().random(length=10)}'
         if user_data is not None:
             user_data.copy_to(self.app_data / 'data')
         self.options = ''

--- a/fixtures/aut.py
+++ b/fixtures/aut.py
@@ -26,7 +26,6 @@ def application_logs():
         for app_data in configs.testpath.STATUS_DATA.iterdir():
             for log in (app_data / 'logs').iterdir():
                 allure.attach.file(log, name=str(log.name), attachment_type=allure.attachment_type.TEXT)
-                log.unlink()
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyperclip==1.8.2
 pytest-rerunfailures==13.0
 pytest-ignore-flaky==2.1.0
 pytest-timeout==2.2.0
+shortuuid==1.0.12


### PR DESCRIPTION
- do not remove application log files after local test runs (it will help investigate issues if any)
- improve folders naming: use uuid for app directory name, and improve test run name to make it more readable
- get rid of 'temp' folder and inner 'status' folder

Result: we have now **local run results** folder (former TEMP) and inside of it there are different run folders which contain application data folders of the applications started. If test is failing, then additional folder is generated with suite name and screenshots. Improved screenshots generation so we don't create unnecessary one now

<img width="1690" alt="Screenshot 2024-03-06 at 18 01 55" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/c7ffc3a5-c9d5-489d-bdbe-6a87b98094b2">

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1598/allure/ 

<img width="1840" alt="Screenshot 2024-03-06 at 19 22 13" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/02fd91f6-6df0-459f-b1d4-1d2499b2f0f9">

