### PR TITLE
chore: improve validation for edit profile form

### DIFF
--- a/gui/components/changes_detected_popup.py
+++ b/gui/components/changes_detected_popup.py
@@ -13,12 +13,16 @@ class ChangesDetectedToastMessage(QObject):
         self._save_button = Button(names.mainWindow_Save_changes_StatusButton)
 
     @allure.step('Save changes')
-    def save(self):
+    def click_save_changes_button(self):
         self._save_button.click()
-        self.wait_until_hidden()
+
+    @allure.step('Check if save changes button is visible')
+    def is_save_changes_button_visible(self):
+        return self._save_button.is_visible
 
 
 class PermissionsChangesDetectedToastMessage(QObject):
+
 
     def __init__(self):
         super().__init__(communities_names.editPermissionView_settingsDirtyToastMessage_SettingsDirtyToastMessage)

--- a/gui/screens/settings_profile.py
+++ b/gui/screens/settings_profile.py
@@ -29,7 +29,7 @@ class ProfileSettingsView(QObject):
 
     @property
     @allure.step('Get display name')
-    def display_name(self) -> str:
+    def get_display_name(self) -> str:
         self._identity_tab_button.click()
         if BuildShowcasePopup().is_visible:
             BuildShowcasePopup().close()
@@ -41,28 +41,25 @@ class ProfileSettingsView(QObject):
         if BuildShowcasePopup().is_visible:
             BuildShowcasePopup().close()
         self._display_name_text_field.text = value
-        self.save_changes()
 
     @property
     @allure.step('Get bio')
-    def bio(self) -> str:
+    def get_bio(self) -> str:
         self._identity_tab_button.click()
         if BuildShowcasePopup().is_visible:
             BuildShowcasePopup().close()
         return self._bio_text_field.text
 
-    @bio.setter
     @allure.step('Set bio')
-    def bio(self, value: str):
+    def set_bio(self, value: str):
         self._identity_tab_button.click()
         if BuildShowcasePopup().is_visible:
             BuildShowcasePopup().close()
         self._bio_text_field.text = value
-        self.save_changes()
 
     @property
     @allure.step('Get social links')
-    def social_links(self) -> dict:
+    def get_social_links(self) -> dict:
         self._web_tab_button.click()
         if BuildShowcasePopup().is_visible:
             BuildShowcasePopup().close()
@@ -75,9 +72,8 @@ class ProfileSettingsView(QObject):
                         links[str(link_name.title)] = str(driver.object.parent(link_value).text)
         return links
 
-    @social_links.setter
     @allure.step('Set social links')
-    def social_links(self, links):
+    def set_social_links(self, links):
         links = {
             0: [links[0]],
             1: [links[1]],
@@ -106,7 +102,7 @@ class ProfileSettingsView(QObject):
         custom_link_text = links[6]
         custom_link = links[7]
 
-        actual_links = self.social_links
+        actual_links = self.get_social_links
 
         assert actual_links['X (Twitter)'] == twitter
         assert actual_links['Personal'] == personal_site
@@ -124,7 +120,4 @@ class ProfileSettingsView(QObject):
         self._add_more_links_label.click()
         return SocialLinksPopup().wait_until_appears()
 
-    @allure.step('Save changes')
-    def save_changes(self):
-        self._save_button.click()
 

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -4,6 +4,7 @@ from allure import step
 
 import constants
 from driver.aut import AUT
+from gui.components.changes_detected_popup import ChangesDetectedToastMessage
 from gui.main_window import MainWindow
 from . import marks
 
@@ -15,7 +16,7 @@ pytestmark = marks
 @pytest.mark.case(703007)
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 @pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13868')
+# @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13868')
 def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
     with step('Open own profile popup and check name of user is correct'):
         profile = main_screen.left_panel.open_online_identifier()
@@ -24,6 +25,9 @@ def test_change_own_display_name(main_screen: MainWindow, user_account, new_name
 
     with step('Go to edit profile settings and change the name of the user'):
         profile_popup.edit_profile().set_name(new_name)
+        ChangesDetectedToastMessage().click_save_changes_button()
+        assert ChangesDetectedToastMessage().is_save_changes_button_visible() is False, \
+            f'Save button is not hidden when clicked'
 
     with step('Open own profile popup and check name of user is correct'):
         assert main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name == new_name

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -16,7 +16,7 @@ pytestmark = marks
 @pytest.mark.case(703007)
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 @pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
-# @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13868')
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13799')
 def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
     with step('Open own profile popup and check name of user is correct'):
         profile = main_screen.left_panel.open_online_identifier()

--- a/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -1,10 +1,8 @@
-import time
 
 import allure
 import pytest
 from allure_commons._allure import step
 
-from gui.screens.settings_profile import ProfileSettingsView
 from . import marks
 
 import constants
@@ -21,7 +19,7 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed',
                          [pytest.param(constants.user.user_account_one, constants.user.user_account_one_changed_name)])
 @pytest.mark.parametrize('bio, links', [pytest.param('This is my bio', constants.social_links)])
-# @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13868')
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13799')
 def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_account, user_account_changed, bio, links):
     with step('Open profile settings and check name, bio and links'):
         profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
@@ -27,7 +27,7 @@ def test_settings_edit_status_account(main_screen: MainWindow, new_name):
 
     with step('Verify Status keypair title'):
         status_keypair_title = settings.get_keypairs_names()[0]
-        profile_display_name = main_screen.left_panel.open_settings().left_panel.open_profile_settings().display_name
+        profile_display_name = main_screen.left_panel.open_settings().left_panel.open_profile_settings().get_display_name
         assert profile_display_name in status_keypair_title, \
             f"Status keypair name should be equal to display name but currently it is {status_keypair_title}, \
              when display name is {profile_display_name}"


### PR DESCRIPTION
Fixes #579 

Tests for edit profile form should now catch the fact if save button was clicked and closed

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1614/allure/#suites/c779a5502ab37d502705212e4949e67a/a4315dd8067931d2/

<img width="1840" alt="Screenshot 2024-03-07 at 13 58 44" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/acd26b5f-08cc-4e90-b6f3-2f700fa3527c">

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1615/allure/#suites/bafa0acf6e88ebdd47b4ecdbd9040f15/facd4f3b61539239/

<img width="1840" alt="Screenshot 2024-03-07 at 13 59 19" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/b59b7ba9-7b0e-4d27-a18a-8d724d64ae5f">

Full run is still good https://ci.status.im/job/status-desktop/job/e2e/job/manual/1618/allure/

<img width="1840" alt="Screenshot 2024-03-07 at 16 08 38" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/03ffa54d-e25f-481a-9636-0160eb0174c1">

