### PR TITLE
chore: reworked toast message verification in tests

### DIFF
--- a/gui/components/toast_message.py
+++ b/gui/components/toast_message.py
@@ -1,6 +1,8 @@
+import typing
+
 import allure
 
-import driver
+from driver.objects_access import walk_children
 from gui.elements.object import QObject
 from gui.objects_map import names
 
@@ -11,14 +13,12 @@ class ToastMessage(QObject):
         super(ToastMessage, self).__init__(names.ephemeral_Notification_List)
         self._toast_message = QObject(names.ephemeralNotificationList_StatusToastMessage)
 
-    @property
     @allure.step('Get toast messages')
-    def get_toast_messages(self):
+    def get_toast_messages(self) -> typing.List[str]:
         messages = []
-        for obj in driver.findAllObjects(self._toast_message.real_name):
-            messages.append(str(obj.primaryText))
+        for child in walk_children(self.object):
+            if getattr(child, 'id', '') == 'title':
+                messages.append(str(child.text))
         if len(messages) == 0:
-            raise LookupError(
-                'Toast messages were not found')
-        else:
-            return messages
+            raise LookupError('Toast message not found')
+        return messages

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 import typing
 
@@ -215,11 +214,11 @@ class MainWindow(Window):
         return app_screen
 
     @allure.step('Wait for notification and get text')
-    def wait_for_notification(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_SEC) -> str:
+    def wait_for_notification(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_SEC) -> list[str]:
         started_at = time.monotonic()
         while True:
             try:
-                return ToastMessage().get_toast_messages
+                return ToastMessage().get_toast_messages()
             except LookupError as err:
                 LOG.info(err)
                 assert time.monotonic() - started_at < timeout_msec, str(err)

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -14,7 +14,6 @@ from gui.components.wallet.popup_delete_account_from_settings import RemoveAccou
 from gui.components.wallet.testnet_mode_popup import TestnetModePopup
 
 from gui.components.wallet.wallet_account_popups import AccountPopup, EditAccountFromSettingsPopup
-from gui.components.toast_message import ToastMessage
 from gui.elements.button import Button
 from gui.elements.check_box import CheckBox
 from gui.elements.object import QObject
@@ -312,22 +311,6 @@ class EditNetworkSettings(WalletSettingsView):
                 return self.click_revert_to_default_and_go_to_networks_main_screen(attempts - 1)
             else:
                 raise f"Networks screen was not opened"
-
-    @allure.step('Check toast message')
-    def check_toast_message(self, network_tab):
-        match network_tab:
-            case WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
-                assert len(ToastMessage().get_toast_messages) == 1, \
-                    f"Multiple toast messages appeared"
-                message = ToastMessage().get_toast_messages[0]
-                assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value, \
-                    f"Toast message is incorrect, current message is {message}"
-            case WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
-                assert len(ToastMessage().get_toast_messages) == 1, \
-                    f"Multiple toast messages appeared"
-                message = ToastMessage().get_toast_messages[0]
-                assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_TEST_MAINNET_TOAST_MESSAGE.value, \
-                    f"Toast message is incorrect, current message is {message}"
 
     @allure.step('Verify elements for the edit network view')
     def check_available_elements_on_edit_view(self, network_tab):

--- a/tests/communities/test_communities_permissions.py
+++ b/tests/communities/test_communities_permissions.py
@@ -5,7 +5,6 @@ from allure_commons._allure import step
 import configs
 from gui.components.changes_detected_popup import PermissionsChangesDetectedToastMessage
 from gui.components.delete_popup import DeletePermissionPopup
-from gui.components.toast_message import ToastMessage
 from gui.screens.community_settings import PermissionsIntroView
 from . import marks
 
@@ -54,13 +53,13 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
         permissions_settings.set_in(in_channel)
         permissions_settings.create_permission()
 
-    # TODO: https://github.com/status-im/desktop-qa-automation/issues/547
-    # with step('Check toast message for permission creation'):
-    #     assert len(ToastMessage().get_toast_messages) == 1, \
-    #         f"Multiple toast messages appeared"
-    #     message = ToastMessage().get_toast_messages[0]
-    #     assert message == ToastMessages.CREATE_PERMISSION_TOAST.value, \
-    #         f"Toast message is incorrect, current message is {message}"
+    with step('Check toast message for permission creation'):
+        toast_messages = main_screen.wait_for_notification()
+        assert len(toast_messages) == 1, \
+            f"Multiple toast messages appeared"
+        message = toast_messages[0]
+        assert message == ToastMessages.CREATE_PERMISSION_TOAST.value, \
+            f"Toast message is incorrect, current message is {message}"
 
     with step('Created permission is displayed on permission page'):
         if asset_title is not False:
@@ -108,11 +107,10 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
             assert driver.waitFor(lambda: permissions_intro_view.is_hide_icon_visible,
                                   configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
-    # TODO: https://github.com/status-im/desktop-qa-automation/issues/547
-    # with step('Check toast message for edited permission'):
-    #    messages = ToastMessage().get_toast_messages
-    #    assert ToastMessages.UPDATE_PERMISSION_TOAST.value in messages, \
-    #        f"Toast message is incorrect, current message is {message}"
+    with step('Check toast message for edited permission'):
+       messages = main_screen.wait_for_notification()
+       assert ToastMessages.UPDATE_PERMISSION_TOAST.value in messages, \
+           f"Toast message is incorrect, current message is {message}"
 
     with step('Delete permission'):
         permissions_intro_view.click_delete_permission()
@@ -121,8 +119,7 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
     with step('Verify that permission was deleted'):
         assert driver.waitFor(lambda: PermissionsIntroView().is_visible)
 
-    # TODO: https://github.com/status-im/desktop-qa-automation/issues/547
-    # with step('Check toast message for deleted permission'):
-    #    messages = ToastMessage().get_toast_messages
-    #    assert ToastMessages.DELETE_PERMISSION_TOAST.value in messages, \
-    #        f"Toast message is incorrect, current message is {message}"
+    with step('Check toast message for deleted permission'):
+       messages = main_screen.wait_for_notification()
+       assert ToastMessages.DELETE_PERMISSION_TOAST.value in messages, \
+           f"Toast message is incorrect, current message is {message}"

--- a/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
@@ -7,7 +7,6 @@ import configs.testpath
 import constants
 from constants import UserAccount
 from constants.messaging import Messaging
-from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 pytestmark = marks
@@ -67,13 +66,13 @@ def test_messaging_settings_accepting_request(multiple_instance, user_data_one, 
             assert user_one.name == contacts_settings.contact_items[0].contact
             assert len(contacts_settings.contact_items) == 1
 
-        # TODO: https://github.com/status-im/desktop-qa-automation/issues/547
-        # with step('Verify toast message about new contact request received'):
-        #    assert len(ToastMessage().get_toast_messages) == 1, \
-        #        f"Multiple toast messages appeared"
-        #    message = ToastMessage().get_toast_messages[0]
-        #    assert message == Messaging.NEW_CONTACT_REQUEST.value, \
-        #        f"Toast message is incorrect, current message is {message}"
+        with step('Verify toast message about new contact request received'):
+            toast_messages = main_window.wait_for_notification()
+            assert len(toast_messages) == 1, \
+                f"Multiple toast messages appeared"
+            message = toast_messages[0]
+            assert message == Messaging.NEW_CONTACT_REQUEST.value, \
+                f"Toast message is incorrect, current message is {message}"
 
         with step(f'User {user_two.name}, accept contact request from {user_one.name}'):
             contacts_settings.accept_contact_request(user_one.name)

--- a/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
@@ -70,11 +70,10 @@ def test_messaging_settings_identity_verification(multiple_instance, user_data_o
             assert not verify_identity_popup.is_send_verification_button_enabled
             verify_identity_popup.type_message('Hi. Is that you?').send_verification()
 
-        # TODO https://github.com/status-im/desktop-qa-automation/issues/547 - will be enabled in this task
-        # with step('Verify toast message about sent ID verification request'):
-        #     toast_messages = main_window.wait_for_notification()
-        #     assert Messaging.ID_VERIFICATION_REQUEST_SENT.value in toast_messages
-        #     main_window.hide()
+        with step('Verify toast message about sent ID verification request'):
+            toast_messages = main_window.wait_for_notification()
+            assert Messaging.ID_VERIFICATION_REQUEST_SENT.value in toast_messages
+            main_window.hide()
 
         with step(f'Check incoming identity request for {user_two.name}'):
             aut_two.attach()
@@ -83,7 +82,6 @@ def test_messaging_settings_identity_verification(multiple_instance, user_data_o
             respond_identity_popup = contacts_settings.open_more_options_popup(user_one.name).respond_to_id_request()
             respond_identity_popup.type_message('Hi. Yes, its me').send_answer()
 
-        # TODO https://github.com/status-im/desktop-qa-automation/issues/547 - will be enabled in this task
-        # with step('Verify toast message about sent ID verification reply'):
-        #     toast_messages = main_window.wait_for_notification()
-        #     assert Messaging.ID_VERIFICATION_REPLY_SENT.value in toast_messages
+        with step('Verify toast message about sent ID verification reply'):
+            toast_messages = main_window.wait_for_notification()
+            assert Messaging.ID_VERIFICATION_REPLY_SENT.value in toast_messages

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -64,7 +64,7 @@ def test_delete_generated_account_from_wallet_settings(
         delete_confirmation_popup.remove_account_with_confirmation()
 
     with step('Verify toast message notification when removing account'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'"{account_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -38,9 +38,9 @@ def test_add_new_account_from_wallet_settings(
         add_account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{account_name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list on main wallet screen'):

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
@@ -61,7 +61,18 @@ def test_settings_networks_edit_restore_defaults(main_screen: MainWindow, networ
         edit_network_form.click_revert_to_default_and_go_to_networks_main_screen()
 
     with step('Verify toast message appears for reverting to defaults'):
-        edit_network_form.check_toast_message(network_tab)
+        if network_tab == WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
+            assert len(main_screen.wait_for_notification()) == 1, \
+                f"Multiple toast messages appeared"
+            message = main_screen.wait_for_notification()[0]
+            assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value, \
+                f"Toast message is incorrect, current message is {message}"
+        elif network_tab == WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
+            assert len(main_screen.wait_for_notification()) == 1, \
+                f"Multiple toast messages appeared"
+            message = main_screen.wait_for_notification()[0]
+            assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_TEST_MAINNET_TOAST_MESSAGE.value, \
+                f"Toast message is incorrect, current message is {message}"
 
     with step('Open Ethereum Mainnet network item to edit'):
         edit_network_form = networks.click_network_item_to_open_edit_view(

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
@@ -30,9 +30,9 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().turn_on_testnet_mode_in_testnet_modal()
 
     with step('Verify that Testnet mode turned on'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE:
@@ -52,8 +52,8 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().turn_off_testnet_mode_in_testnet_modal()
 
     with step('Verify that Testnet mode turned off'):
-        assert len(ToastMessage().get_toast_messages) == 2
-        message = ToastMessage().get_toast_messages[1]
+        assert len(main_screen.wait_for_notification()) == 2
+        message = main_screen.wait_for_notification()[1]
         assert message == WalletNetworkSettings.TESTNET_DISABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE:
@@ -105,9 +105,9 @@ def test_switch_testnet_off_by_toggle_and_cancel_in_confirmation(main_screen: Ma
         testnet_modal.turn_on_testnet_mode_in_testnet_modal()
 
     with step('Verify testnet mode is enabled'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE:

--- a/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
@@ -42,7 +42,7 @@ def test_wallet_settings_add_saved_address(main_screen: MainWindow, address: str
             configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {name} not found'
 
     with step('Verify toast message when adding saved address'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'{name} successfully added to your saved addresses' in messages, \
             f"Toast message about adding saved address is not correct or not present. \
                 Current list of messages: {messages}"

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_add_account_after_restart.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_add_account_after_restart.py
@@ -40,9 +40,9 @@ def test_add_generated_account_restart_add_again(
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -67,9 +67,9 @@ def test_add_generated_account_restart_add_again(
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name2}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_add_watched_address.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_add_watched_address.py
@@ -35,9 +35,9 @@ def test_plus_button_add_watched_address(
             f"Authentication should not appear for adding watched addresses"
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
@@ -38,9 +38,9 @@ def test_plus_button_manage_account_added_for_new_seed(main_screen: MainWindow, 
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -67,7 +67,7 @@ def test_plus_button_manage_account_added_for_new_seed(main_screen: MainWindow, 
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_account_from_private_key.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_account_from_private_key.py
@@ -38,9 +38,9 @@ def test_plus_button_manage_account_from_private_key(main_screen: MainWindow, us
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -77,7 +77,7 @@ def test_plus_button_manage_account_from_private_key(main_screen: MainWindow, us
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_account_from_seed_phrase.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_account_from_seed_phrase.py
@@ -47,9 +47,9 @@ def test_plus_button_manage_account_from_seed_phrase(main_screen: MainWindow, us
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -76,7 +76,7 @@ def test_plus_button_manage_account_from_seed_phrase(main_screen: MainWindow, us
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_generated_account.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_generated_account.py
@@ -33,9 +33,9 @@ def test_plus_button_manage_generated_account(main_screen: MainWindow, user_acco
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -62,7 +62,7 @@ def test_plus_button_manage_generated_account(main_screen: MainWindow, user_acco
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
+++ b/tests/wallet_main_screen/wallet: plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
@@ -49,9 +49,9 @@ def test_plus_button_manage_generated_account_custom_derivation_path(main_screen
                 raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Edit wallet account'):
@@ -70,7 +70,7 @@ def test_plus_button_manage_generated_account_custom_derivation_path(main_screen
         wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
 
     with step('Verify toast message notification when removing account'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/tests/wallet_main_screen/wallet: right click out of account area/test_right_click_manage_watched_address.py
+++ b/tests/wallet_main_screen/wallet: right click out of account area/test_right_click_manage_watched_address.py
@@ -36,9 +36,9 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        assert len(ToastMessage().get_toast_messages) == 1, \
+        assert len(main_screen.wait_for_notification()) == 1, \
             f"Multiple toast messages appeared"
-        message = ToastMessage().get_toast_messages[0]
+        message = main_screen.wait_for_notification()[0]
         assert message == f'"{name}" successfully added'
 
     with step('Right click recently watched address and select edit option'):

--- a/tests/wallet_main_screen/wallet: saved addresses/test_saved_addresses.py
+++ b/tests/wallet_main_screen/wallet: saved addresses/test_saved_addresses.py
@@ -39,7 +39,7 @@ def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, 
             configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {name} not found'
 
     with step('Verify toast message when adding saved address'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'{name} successfully added to your saved addresses' in messages, \
             f"Toast message about adding saved address is not correct or not present. Current list of messages: {messages}"
 
@@ -52,7 +52,7 @@ def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, 
             configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {new_name} not found'
 
     with step('Verify toast message when editing saved address'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'{new_name} saved address successfully edited' in messages, \
             f"Toast message about editing saved address is not correct or not present. Current list of messages: {messages}"
 
@@ -60,7 +60,7 @@ def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, 
         wallet.left_panel.open_saved_addresses().delete_saved_address(new_name)
 
     with step('Verify toast message when deleting saved address'):
-        messages = ToastMessage().get_toast_messages
+        messages = main_screen.wait_for_notification()
         assert f'{new_name} was successfully removed from your saved addresses' in messages, \
             f"Toast message about deleting saved address is not correct or not present. Current list of messages: {messages}"
 


### PR DESCRIPTION
- Reworked methods of getting toast messages
- Replaced in steps to wait_for_notification method

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1628/allure/