### PR TITLE
chore: enable tests for editing profile

### DIFF
--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -16,7 +16,6 @@ pytestmark = marks
 @pytest.mark.case(703007)
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 @pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13799')
 def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
     with step('Open own profile popup and check name of user is correct'):
         profile = main_screen.left_panel.open_online_identifier()

--- a/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -19,7 +19,6 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed',
                          [pytest.param(constants.user.user_account_one, constants.user.user_account_one_changed_name)])
 @pytest.mark.parametrize('bio, links', [pytest.param('This is my bio', constants.social_links)])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/13799')
 def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_account, user_account_changed, bio, links):
     with step('Open profile settings and check name, bio and links'):
         profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()


### PR DESCRIPTION
Enable back tests that were disabled because of https://github.com/status-im/status-desktop/issues/13799

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1634/allure/#suites/bafa0acf6e88ebdd47b4ecdbd9040f15/e5765c4125cd8e33/

I logged a task to re-work this "partial" click that happens from time to time https://github.com/status-im/desktop-qa-automation/issues/585

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1635/allure/#suites/dc13814b122239ff980c4e5033f4b805