### PR TITLE
chore: remove duplicated click

### DIFF
--- a/gui/components/onboarding/before_started_popup.py
+++ b/gui/components/onboarding/before_started_popup.py
@@ -25,7 +25,7 @@ class BeforeStartedPopUp(BasePopup):
     @allure.step('Allow all and get started')
     def get_started(self):
         self._acknowledge_checkbox.set(True)
-        self._terms_of_use_checkBox.set(True, x=10)
+        self._terms_of_use_checkBox.set(True)
         assert self._terms_of_use_link.is_visible, f"Terms of use link is missing"
         assert self._privacy_policy_link.is_visible, f"Privacy Policy link is missing"
         self._get_started_button.click()

--- a/gui/components/wallet/add_saved_address_popup.py
+++ b/gui/components/wallet/add_saved_address_popup.py
@@ -73,11 +73,11 @@ class AddressPopup(AddSavedAddressPopup):
         self._address_text_edit.type_text(address)
         if address.startswith("0x"):
             self.verify_network_selector_enabled()
-            self._add_networks_selector.click(1, 1)
+            self._add_networks_selector.click()
             self.set_ethereum_mainnet_network(True)
             self.set_optimism_mainnet_network(True)
             self.set_arbitrum_mainnet_network(True)
-            self._save_add_address_button.click()  # click it twice to close the network selector pop up
+            self._name_text_edit.click()  # click the text field to close the network selector pop up
             self.verify_ethereum_mainnet_network_tag_present()
             self.verify_otimism_mainnet_network_tag_present()
             self.verify_arbitrum_mainnet_network_tag_present(),

--- a/gui/elements/button.py
+++ b/gui/elements/button.py
@@ -10,16 +10,4 @@ LOG = logging.getLogger(__name__)
 
 
 class Button(QObject):
-
-    @allure.step('Click {0}')
-    def click(
-            self,
-            x: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
-            y: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
-            button: driver.MouseButton = None
-    ):
-        if None not in (x, y, button):
-            getattr(self.object, 'clicked')()
-            LOG.info('%s: clicked', self)
-        else:
-            super(Button, self).click(x, y, button)
+    pass

--- a/gui/elements/check_box.py
+++ b/gui/elements/check_box.py
@@ -12,9 +12,9 @@ LOG = logging.getLogger(__name__)
 class CheckBox(QObject):
 
     @allure.step("Set {0} value: {1}")
-    def set(self, value: bool, x: int = None, y: int = None):
+    def set(self, value: bool):
         if self.is_checked is not value:
-            self.click(x, y)
+            self.click()
             assert driver.waitFor(
                 lambda: self.is_checked is value, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Value not changed'
         LOG.info('%s: value changed to "%s"', self, value)

--- a/gui/elements/object.py
+++ b/gui/elements/object.py
@@ -96,36 +96,22 @@ class QObject:
     ):
         driver.mouseClick(
             self.object,
-            x or self.width // 2,
-            y or self.height // 2,
+            x or int(self.object.width * 0.1),
+            y or int(self.object.height * 0.1),
             button or driver.Qt.LeftButton
         )
-        LOG.info('%s: clicked', self)
+        LOG.info('%s: is clicked with Qt.LeftButton', self)
 
     @allure.step('Native click {0}')
-    def native_click(
+    def native_mouse_click(
             self,
             x: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
             y: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
             button: driver.MouseButton = None
     ):
         driver.nativeMouseClick(
-            x or self.bounds.x + self.width // 2,
-            y or self.bounds.y + self.height // 2,
-            button or driver.MouseButton.LeftButton
-        )
-        LOG.info(f'{self}: native clicked')
-
-    @allure.step('Native click {0}')
-    def native_click(
-            self,
-            x: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
-            y: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
-            button: driver.MouseButton = None
-    ):
-        driver.nativeMouseClick(
-            x or self.bounds.x + self.width // 2,
-            y or self.bounds.y + self.height // 2,
+            x or int(self.bounds.x + self.width // 2),
+            y or int(self.bounds.y + self.height // 2),
             button or driver.MouseButton.LeftButton
         )
         LOG.info(f'{self}: native clicked')
@@ -145,18 +131,18 @@ class QObject:
         assert driver.waitFor(lambda: _hover(), timeout_msec)
         return self
 
-    @allure.step('Open context menu')
-    def open_context_menu(
+    @allure.step('Right click on {0}')
+    def right_click(
             self,
             x: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
             y: typing.Union[int, driver.UiTypes.ScreenPoint] = None,
     ):
         self.click(
-            x or self.width // 2,
-            y or self.height // 2,
+            x or int(self.width // 2),
+            y or int(self.height // 2),
             driver.Qt.RightButton
         )
-        LOG.info('%s: clicked via Right Mouse Button', self)
+        LOG.info('%s: right clicked with Qt.RightButton', self)
 
     @allure.step('Wait until appears {0}')
     def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -127,7 +127,7 @@ class LeftPanel(QObject):
     @allure.step('Open context menu for community')
     def open_community_context_menu(self, name: str) -> ContextMenu:
         driver.objectMap.realName(self._get_community(name))['name'] = name
-        self._get_community(name).open_context_menu()
+        self._get_community(name).right_click()
         return ContextMenu().wait_until_appears()
 
     @allure.step('Invite people in community')

--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -301,12 +301,12 @@ class LeftPanel(QObject):
 
     @allure.step('Open general channel context menu')
     def open_general_channel_context_menu(self):
-        self._general_channel_item.open_context_menu()
+        self._general_channel_item.right_click()
         return ContextMenu()
 
     @allure.step('Open category context menu')
     def open_category_context_menu(self):
-        self._category_list_item.open_context_menu()
+        self._category_list_item.right_click()
 
     @allure.step('Open create category popup')
     def open_create_category_popup(self, attempts: int = 2) -> NewCategoryPopup:
@@ -385,7 +385,7 @@ class LeftPanel(QObject):
 
     @allure.step('Right click on left panel')
     def right_click_on_panel(self):
-        super(LeftPanel, self).open_context_menu()
+        super(LeftPanel, self).right_click()
 
 
 class Chat(QObject):

--- a/gui/screens/messages.py
+++ b/gui/screens/messages.py
@@ -50,7 +50,7 @@ class LeftPanel(QObject):
     @allure.step('Open context menu group chat')
     def _open_context_menu_for_chat(self, chat_name: str) -> ContextMenu:
         self._contact_item.real_name['objectName'] = chat_name
-        self._contact_item.open_context_menu()
+        self._contact_item.right_click()
         return ContextMenu().wait_until_appears()
 
     @allure.step('Open leave popup')

--- a/gui/screens/wallet.py
+++ b/gui/screens/wallet.py
@@ -83,14 +83,14 @@ class LeftPanel(QObject):
     @allure.step('Open context menu from left wallet panel')
     @close_exists(BasePopup())
     def _open_context_menu(self) -> ContextMenu:
-        super(LeftPanel, self).open_context_menu()
+        super(LeftPanel, self).right_click()
         return ContextMenu().wait_until_appears()
 
     @allure.step('Open context menu for account')
     @close_exists(BasePopup())
     def _open_context_menu_for_account(self, account_name: str) -> ContextMenu:
         self._wallet_account_item.real_name['title'] = account_name
-        self._wallet_account_item.wait_until_appears().open_context_menu()
+        self._wallet_account_item.wait_until_appears().right_click()
         return ContextMenu().wait_until_appears()
 
     @allure.step("Select Hide/Include in total balance from context menu for account")
@@ -175,17 +175,17 @@ class SavedAddressesView(QObject):
 
     @allure.step('Open edit address popup for saved address')
     def open_edit_address_popup(self, name: str) -> 'EditSavedAddressPopup':
-        self.open_context_menu(name).select_edit_saved_address()
+        self.right_click(name).select_edit_saved_address()
         return EditSavedAddressPopup()
 
     @allure.step('Delete saved address from the list')
     def delete_saved_address(self, address_name):
-        self.open_context_menu(address_name).select_delete_saved_address()
+        self.right_click(address_name).select_delete_saved_address()
         assert ConfirmationPopup().get_confirmation_text().startswith('Are you sure you want to remove')
         ConfirmationPopup().confirm()
 
     @allure.step('Open context menu in saved address')
-    def open_context_menu(self, name) -> ContextMenu:
+    def right_click(self, name) -> ContextMenu:
         self._open_menu_button.real_name['objectName'] = 'savedAddressView_Delegate_menuButton' + '_' + name
         self._address_list_item.real_name['objectName'] = 'savedAddressView_Delegate' + '_' + name
         self._address_list_item.hover()


### PR DESCRIPTION
Closes #585 

CI run_1 full scope: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1660/allure/
CI run_2 full scope: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1662/console

Removed duplicated native click
Aligned click with left and right buttons to both using Qt buttons
Renamed a method of right clicking to be named like that
Removed unnecessary (?) extra click method in Button class

```
x or int(self.object.width * 0.1),
y or int(self.object.height * 0.1),
```
this is done to avoid clicking in the middle of the object, also these params must be int otherwise they are not accepted by mouseClick and then it is defaulted to click to the center of the object. We dont want to have that just because for some elements (like checkboxes) clicking in the center may lead to click any other element like link (see screenshot)

![image](https://github.com/status-im/desktop-qa-automation/assets/82375995/79a93487-f8d6-4ef9-9464-6b0d89d9fa0b)

![image](https://github.com/status-im/desktop-qa-automation/assets/82375995/e8ee296b-8c8a-473b-9916-b704b0213ad0)
