### PR TITLE
chore: bring back logs clean up

### DIFF
--- a/fixtures/aut.py
+++ b/fixtures/aut.py
@@ -26,6 +26,7 @@ def application_logs():
         for app_data in configs.testpath.STATUS_DATA.iterdir():
             for log in (app_data / 'logs').glob('*.log'):
                 allure.attach.file(log, name=str(log.name), attachment_type=allure.attachment_type.TEXT)
+                log.unlink()
 
 
 @pytest.fixture


### PR DESCRIPTION
I am brining back logs removal in application logs function just because having so many files right now in allure report is annoying.

This will again leave us with logs folder empty for local runs. I think, this function should be revisited again later, desired bahvior:
- we have logs in logs folder when running tests locally
- we also have logs (1 file per test) attached in allure report

Will work on that later 