### PR TITLE
Chore/fix nightly

### DIFF
--- a/gui/components/changes_detected_popup.py
+++ b/gui/components/changes_detected_popup.py
@@ -17,7 +17,7 @@ class ChangesDetectedToastMessage(QObject):
         self._save_button.click()
 
     @allure.step('Check if save changes button is visible')
-    def is_save_changes_button_visible(self):
+    def is_save_changes_button_visible(self) -> bool:
         return self._save_button.is_visible
 
 
@@ -25,7 +25,7 @@ class PermissionsChangesDetectedToastMessage(QObject):
 
     def __init__(self):
         super().__init__(communities_names.editPermissionView_settingsDirtyToastMessage_SettingsDirtyToastMessage)
-        self._update_permission_button = Button(communities_names.editPermissionView_Save_changes_StatusButton)
+        self._update_permission_button = Button(communities_names.editPermissionView_Update_permission_StatusButton)
 
     @allure.step('Update permission')
     def update_permission(self):

--- a/gui/objects_map/communities_names.py
+++ b/gui/objects_map/communities_names.py
@@ -159,7 +159,8 @@ communityEditPanelScrollView_requestToJoinToggle_StatusCheckBox = {"checkable": 
 communityEditPanelScrollView_pinMessagesToggle_StatusCheckBox = {"checkable": True, "container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "id": "pinMessagesToggle", "type": "StatusCheckBox", "unnamed": 1, "visible": True}
 communityEditPanelScrollView_editCommunityIntroInput_TextEdit = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCommunityIntroInput", "type": "TextEdit", "visible": True}
 communityEditPanelScrollView_editCommunityOutroInput_TextEdit = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCommunityOutroInput", "type": "TextEdit", "visible": True}
-editPermissionView_Save_changes_StatusButton = {"container": mainWindow_editPermissionView_EditPermissionView, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
+editPermissionView_Update_permission_StatusButton = {"checkable": False, "container": mainWindow_editPermissionView_EditPermissionView, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
+
 croppedImageEditLogo = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCroppedImageItem_Community logo", "type": "EditCroppedImagePanel", "visible": True}
 croppedImageEditBanner = {"container": mainWindow_communityEditPanelScrollView_EditSettingsPanel, "objectName": "editCroppedImageItem_Community banner", "type": "EditCroppedImagePanel", "visible": True}
 

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -11,7 +11,7 @@ splashScreen = {"container": statusDesktop_mainWindow, "objectName": "splashScre
 
 # Common names
 settingsSave_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
-mainWindow_Save_changes_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "DisabledTooltipButton", "visible": True}
+mainWindow_Save_changes_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
 closeCrossPopupButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerActionsCloseButton", "type": "StatusFlatRoundButton", "visible": True}
 
 # Main right panel

--- a/tests/communities/test_communities_permissions.py
+++ b/tests/communities/test_communities_permissions.py
@@ -108,9 +108,9 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
                                   configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     with step('Check toast message for edited permission'):
-       messages = main_screen.wait_for_notification()
-       assert ToastMessages.UPDATE_PERMISSION_TOAST.value in messages, \
-           f"Toast message is incorrect, current message is {message}"
+        messages = main_screen.wait_for_notification()
+        assert ToastMessages.UPDATE_PERMISSION_TOAST.value in messages, \
+            f"Toast message is incorrect, current message is {message}"
 
     with step('Delete permission'):
         permissions_intro_view.click_delete_permission()
@@ -120,6 +120,6 @@ def test_add_edit_and_remove_permissions(main_screen: MainWindow, params, checkb
         assert driver.waitFor(lambda: PermissionsIntroView().is_visible)
 
     with step('Check toast message for deleted permission'):
-       messages = main_screen.wait_for_notification()
-       assert ToastMessages.DELETE_PERMISSION_TOAST.value in messages, \
-           f"Toast message is incorrect, current message is {message}"
+        messages = main_screen.wait_for_notification()
+        assert ToastMessages.DELETE_PERMISSION_TOAST.value in messages, \
+            f"Toast message is incorrect, current message is {message}"

--- a/tests/online_identifier/test_online_identifier.py
+++ b/tests/online_identifier/test_online_identifier.py
@@ -31,8 +31,7 @@ def test_change_own_display_name(main_screen: MainWindow, user_account, new_name
     with step('Go to edit profile settings and change the name of the user'):
         profile_popup.edit_profile().set_name(new_name)
         ChangesDetectedToastMessage().click_save_changes_button()
-        assert ChangesDetectedToastMessage().is_save_changes_button_visible() is False, \
-            f'Save button is not hidden when clicked'
+        assert ChangesDetectedToastMessage().is_visible is False, f'Changes detected popup is not hidden when save changes button clicked'
 
     with step('Open own profile popup and check name of user is correct'):
         assert main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name == new_name


### PR DESCRIPTION
- Fixed locators for save changes buttons
- Fixed verification that save button is not visible (replaced with verification that popup is not visible, test for some reason keeps seeing save changes as visible)

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1668/allure/