### PR TITLE
chore: skip test_member_role_cannot_add_edit_or_delete_category

### DIFF
--- a/tests/communities/test_communities_categories.py
+++ b/tests/communities/test_communities_categories.py
@@ -81,6 +81,7 @@ def test_create_edit_remove_community_category(main_screen: MainWindow, category
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703274', 'Member role cannot remove category')
 @pytest.mark.case(703272, 703273, 703274)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
+@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/603')
 def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
         community_screen = main_screen.left_panel.select_community('Super community')

--- a/tests/communities/test_communities_categories.py
+++ b/tests/communities/test_communities_categories.py
@@ -81,7 +81,7 @@ def test_create_edit_remove_community_category(main_screen: MainWindow, category
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703274', 'Member role cannot remove category')
 @pytest.mark.case(703272, 703273, 703274)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
-@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/603')
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/14059')
 def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
         community_screen = main_screen.left_panel.select_community('Super community')


### PR DESCRIPTION
Test skipped because now I cannot update user data (because of bug https://github.com/status-im/status-desktop/issues/14011). So I created a separate task and will update user data and enable test back later