### PR TITLE
chore: add missing marks and enabled profile edit test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ markers =
     settings_keycard: Tests related to Keycard settings
     settings_messaging: Tests related to messaging settings
     settings_profile: Tests related to profile settings
+    settings_password: Tests related to password settings
     settings_wallet: Tests related to wallet settings
     messaging: All tests related to 1x1 chat and group chat functionality
     communities: All tests related to communities functionality

--- a/tests/communities/test_communities_categories.py
+++ b/tests/communities/test_communities_categories.py
@@ -18,7 +18,8 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703235', 'Edit category - remove channel')
 @pytest.mark.case(703226, 703233, 703234, 703235, 703227)
 @pytest.mark.parametrize(
-    'category_name, general_checkbox, channel_name, channel_description, channel_emoji, second_channel_name, second_channel_description, second_channel_emoji',
+    'category_name, general_checkbox, channel_name, channel_description, channel_emoji, second_channel_name, '
+    'second_channel_description, second_channel_emoji',
     [pytest.param('Category in general', True, 'Channel', 'Description', 'sunglasses', 'Second-channel',
                   'Description', 'sunglasses')])
 def test_create_edit_remove_community_category(main_screen: MainWindow, category_name, general_checkbox, channel_name,

--- a/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
+++ b/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
@@ -5,9 +5,11 @@ import constants
 import pytest
 from allure_commons._allure import step
 from constants import UserAccount
+from . import marks
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
 
+pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704610', 'Reject a contact request with a chat key')
 @pytest.mark.case(704610)

--- a/tests/settings/settings_password/__init__.py
+++ b/tests/settings/settings_password/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+from .. import marks
+
+marks = [pytest.mark.settings_password, marks]

--- a/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -19,7 +19,6 @@ pytestmark = marks
 @pytest.mark.parametrize('user_account, user_account_changed',
                          [pytest.param(constants.user.user_account_one, constants.user.user_account_one_changed_name)])
 @pytest.mark.parametrize('bio, links', [pytest.param('This is my bio', constants.social_links)])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/pull/13900')
 def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_account, user_account_changed, bio, links):
     with step('Open profile settings and check name, bio and links'):
         profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()
@@ -31,8 +30,8 @@ def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_accou
         profile_settings.set_name(user_account_changed.name)
         profile_settings.set_bio(bio)
         ChangesDetectedToastMessage().click_save_changes_button()
-        assert ChangesDetectedToastMessage().is_save_changes_button_visible() is False, \
-            f'Save button is not hidden when clicked'
+        assert ChangesDetectedToastMessage().is_visible is False, \
+            f'Bottom floating buttons are not hidden'
         assert \
             main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name \
             == user_account_changed.name, \
@@ -40,8 +39,8 @@ def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_accou
         main_screen.left_panel.click()
         profile_settings.set_social_links(links)
         ChangesDetectedToastMessage().click_save_changes_button()
-        assert ChangesDetectedToastMessage().is_save_changes_button_visible() is False, \
-            f'Save button is not hidden when clicked'
+        assert ChangesDetectedToastMessage().is_visible is False, \
+            f'Bottom floating buttons are not hidden'
         assert len(profile_settings.get_social_links) > 0, f'No social links were added'
 
     with step('Restart application'):

--- a/tests/settings/settings_wallet/test_wallet_settings_account_order.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_account_order.py
@@ -7,8 +7,7 @@ import configs
 import driver
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.main_window import MainWindow, LeftPanel
-from scripts.tools import image
+from gui.main_window import MainWindow
 
 pytestmark = marks
 

--- a/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_delete_account.py
@@ -11,7 +11,6 @@ import driver
 from constants.wallet import WalletAccountSettings, DerivationPath
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 from gui.screens.settings_wallet import WalletSettingsView
 

--- a/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -10,7 +10,6 @@ from . import marks
 import constants
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.wallet.authenticate_popup import AuthenticatePopup
-from gui.components.toast_message import ToastMessage
 from gui.main_window import MainWindow
 
 pytestmark = marks

--- a/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
@@ -10,6 +10,8 @@ from constants.wallet import WalletNetworkNaming, WalletEditNetworkErrorMessages
 from gui.main_window import MainWindow
 
 pytestmark = marks
+
+
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703515',
                  'Network:  Network: Editing network -> Restore defaults')
 @pytest.mark.case(703515)
@@ -18,7 +20,6 @@ pytestmark = marks
     pytest.param(WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value)
 ])
 def test_settings_networks_edit_restore_defaults(main_screen: MainWindow, network_tab: str):
-
     networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
 
     with step('Check network items titles'):

--- a/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
@@ -5,7 +5,6 @@ import allure
 import pytest
 from allure_commons._allure import step
 
-from gui.components.toast_message import ToastMessage
 from . import marks
 
 import configs

--- a/tests/settings/test_ens_name_purchase.py
+++ b/tests/settings/test_ens_name_purchase.py
@@ -7,6 +7,7 @@ import constants
 import driver
 from configs.timeouts import UI_LOAD_TIMEOUT_SEC
 from constants.wallet import WalletTransactions
+from . import marks
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
 from gui.components.splash_screen import SplashScreen
@@ -15,7 +16,7 @@ from gui.components.wallet.send_popup import SendPopup
 from gui.screens.onboarding import KeysView, AllowNotificationsView, WelcomeToStatusView, BiometricsView
 from gui.screens.settings_ens_usernames import ENSRegisteredView
 
-
+pytestmark = marks
 @pytest.fixture
 def keys_screen(main_window) -> KeysView:
     with step('Open Generate new keys view'):

--- a/tests/settings/test_settings_back_up_seed.py
+++ b/tests/settings/test_settings_back_up_seed.py
@@ -4,7 +4,6 @@ from allure_commons._allure import step
 from . import marks
 
 import configs
-import driver
 from gui.components.back_up_your_seed_phrase_banner import BackUpSeedPhraseBanner
 from gui.main_window import MainWindow
 


### PR DESCRIPTION
Enabled back `test_settings_profile_edit`, changed assert messages, added missing marks where noticed, removed unused imports