### PR TITLE
test: assets sorting test added

### DIFF
--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -751,10 +751,20 @@ savedAddressesArea_SavedAddresses = {"container": mainWindow_SavedAddressesView,
 savedAddresses_area = {"container": mainWindow_SavedAddressesView_2, "objectName": "savedAddressesArea", "type": "SavedAddresses", "visible": True}
 
 # Wallet Account View
-mainWindow_StatusSectionLayout_ContentItem = {"container": statusDesktop_mainWindow, "objectName": "StatusSectionLayout", "type": "ContentItem", "visible": True}
 mainWindow_RightTabView = {"container": statusDesktop_mainWindow, "type": "RightTabView", "unnamed": 1, "visible": True}
 mainWallet_Account_Name = {"container": mainWindow_RightTabView, "objectName": "walletHeaderTitle", "type": "StatusBaseText", "visible": True}
 mainWindow_Send_Button = {"container": mainWindow_StatusWindow, "type": "DisabledTooltipButton", "icon": "send", "visible": True}
+mainWindow_RightTabView = {"container": mainWindow_StatusWindow, "type": "RightTabView", "unnamed": 1, "visible": True}
+filterButton_StatusFlatButton = {"checkable": True, "container": mainWindow_RightTabView, "objectName": "filterButton", "type": "StatusFlatButton", "visible": True}
+cmbTokenOrder_SortOrderComboBox = {"container": mainWindow_RightTabView, "objectName": "cmbTokenOrder", "type": "SortOrderComboBox", "visible": True}
+rightSideWalletTabBar_StatusTabBar = {"container": mainWindow_RightTabView, "objectName": "rightSideWalletTabBar", "type": "StatusTabBar", "visible": True}
+rightSideWalletTabBar_Assets_StatusTabButton = {"checkable": True, "container": rightSideWalletTabBar_StatusTabBar, "objectName": "assetsTabButton", "text": "Assets", "type": "StatusTabButton", "visible": True}
+rightSideWalletTabBar_Collectibles_StatusTabButton = {"checkable": True, "container": rightSideWalletTabBar_StatusTabBar, "objectName": "collectiblesTabButton", "text": "Collectibles", "type": "StatusTabButton", "visible": True}
+rightSideWalletTabBar_Activity_StatusTabButton = {"checkable": True, "container": rightSideWalletTabBar_StatusTabBar, "objectName": "activityTabButton", "text": "Activity", "type": "StatusTabButton", "visible": True}
+o_AssetsView = {"container": mainWindow_RightTabView, "type": "AssetsView", "unnamed": 1, "visible": True}
+itemDelegate = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "id": "menuDelegate", "type": "ItemDelegate", "unnamed": 1, "visible": True}
+assetView_TokenListItem_TokenDelegate = {"container": mainWindow_RightTabView, "objectName": RegularExpression("AssetView_TokenListItem_*"), "type": "TokenDelegate", "visible": True}
+arrow_icon_StatusIcon = {"container": statusDesktop_mainWindow_overlay, "objectName": "arrow-up-icon", "type": "StatusIcon", "visible": True}
 
 # MOCKED KEYCARD CONTROLLER NAMES
 

--- a/gui/screens/wallet.py
+++ b/gui/screens/wallet.py
@@ -1,3 +1,4 @@
+import time
 import typing
 
 import allure
@@ -14,6 +15,7 @@ from gui.components.wallet.remove_wallet_account_popup import RemoveWalletAccoun
 from gui.components.wallet.send_popup import SendPopup
 from gui.components.wallet.wallet_account_popups import AccountPopup
 from gui.elements.button import Button
+from gui.elements.list import List
 from gui.elements.object import QObject
 from gui.elements.text_label import TextLabel
 from gui.objects_map import names
@@ -195,6 +197,13 @@ class WalletAccountView(QObject):
         self._account_name_text_label = TextLabel(names.mainWallet_Account_Name)
         self._addresses_panel = QObject(names.mainWallet_Address_Panel)
         self._send_button = Button(names.mainWindow_Send_Button)
+        self._filter_button = Button(names.filterButton_StatusFlatButton)
+        self._assets_combobox = List(names.cmbTokenOrder_SortOrderComboBox)
+        self._assets_tab_button = Button(names.rightSideWalletTabBar_Assets_StatusTabButton)
+        self._collectibles_tab_button = Button(names.rightSideWalletTabBar_Collectibles_StatusTabButton)
+        self._asset_item_delegate = QObject(names.itemDelegate)
+        self._asset_item = QObject(names.assetView_TokenListItem_TokenDelegate)
+        self._arrow_icon = QObject(names.arrow_icon_StatusIcon)
 
     @property
     @allure.step('Get name of account')
@@ -215,3 +224,50 @@ class WalletAccountView(QObject):
     def open_send_popup(self) -> SendPopup:
         self._send_button.click()
         return SendPopup().wait_until_appears()
+
+    @allure.step('Open assets tab')
+    def open_assets_tab(self):
+        self._assets_tab_button.click()
+        return self
+
+    @allure.step('Open collectibles tab')
+    def open_collectibles_tab(self):
+        self._collectibles_tab_button.click()
+        return self
+
+    @allure.step('Click filter button')
+    def click_filter_button(self):
+        self._filter_button.click()
+        return self
+
+    @allure.step('Get value from combobox')
+    def get_combobox_value(self) -> str:
+        return str(self._assets_combobox.object.displayText)
+
+    @allure.step('Choose sort by value')
+    def choose_sort_by_value(self, sort_by_value: str):
+        self._assets_combobox.click()
+        driver.mouseClick(self.get_sort_by_item_object(sort_by_value))
+
+    @allure.step('Get sort by item')
+    def get_sort_by_item_object(self, sort_by_value: str):
+        for item in driver.findAllObjects(self._asset_item_delegate.real_name):
+            if getattr(item, 'text', '') == sort_by_value:
+                return item
+
+    @allure.step('Click the arrow button')
+    def click_arrow_button(self, arrow_name: str, occurrence: int):
+        self._assets_combobox.click()
+        self._arrow_icon.real_name['objectName'] = arrow_name
+        if occurrence > 1:
+            self._arrow_icon.real_name['occurrence'] = occurrence
+        self._arrow_icon.click()
+
+    @allure.step('Get list of assets')
+    def get_list_of_assets(self) -> typing.List:
+        time.sleep(1)
+        token_list_items = []
+        for item in driver.findAllObjects(self._asset_item.real_name):
+            token_list_items.append(item)
+        sorted(token_list_items, key=lambda item: item.y)
+        return token_list_items

--- a/tests/wallet_main_screen/wallet: assets tab/test_wallet_assets_sorting.py
+++ b/tests/wallet_main_screen/wallet: assets tab/test_wallet_assets_sorting.py
@@ -12,17 +12,17 @@ from gui.main_window import MainWindow
 pytestmark = marks
 
 
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704636',
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727223',
                  'Sort by Asset balance value')
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704677',
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727224',
                  'Sort by Asset balance')
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704678',
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727225',
                  'Sort by Asset value')
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704679',
-                 'Sort by 1W change: balance value')
-@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704680',
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727226',
+                 'Sort by 1d change: balance value')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727227',
                  'Sort by Asset name')
-@pytest.mark.case(704636, 704677, 704678, 704679, 704680)
+@pytest.mark.case(727223, 727224, 727225, 727226, 727227)
 @pytest.mark.parametrize('address, name, dai, weenus, stt, eth', [
     pytest.param('0xFf58d746A67C2E42bCC07d6B3F58406E8837E883', 'AssetsCollectibles', 'Dai Stablecoin', 'WEENUS Token',
                  'Status Test Token', 'Ether')

--- a/tests/wallet_main_screen/wallet: assets_sorting/test_wallet_sorting.py
+++ b/tests/wallet_main_screen/wallet: assets_sorting/test_wallet_sorting.py
@@ -1,0 +1,134 @@
+import allure
+import pytest
+from allure_commons._allure import step
+
+import driver
+from gui.screens.wallet import WalletAccountView
+from tests.wallet_main_screen import marks
+
+from gui.components.signing_phrase_popup import SigningPhrasePopup
+from gui.main_window import MainWindow
+
+pytestmark = marks
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704636',
+                 'Sort by Asset balance value')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704677',
+                 'Sort by Asset balance')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704678',
+                 'Sort by Asset value')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704679',
+                 'Sort by 1W change: balance value')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704680',
+                 'Sort by Asset name')
+@pytest.mark.case(704636, 704677, 704678, 704679, 704680)
+@pytest.mark.parametrize('address, name, dai, weenus, stt, eth', [
+    pytest.param('0xFf58d746A67C2E42bCC07d6B3F58406E8837E883', 'AssetsCollectibles', 'Dai Stablecoin', 'WEENUS Token',
+                 'Status Test Token', 'Ether')
+])
+def test_wallet_sort_assets(main_screen: MainWindow, address, name, dai, weenus, stt, eth):
+    with step('Turn on Testnet mode'):
+        networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()
+        networks.switch_testnet_mode_toggle().turn_on_testnet_mode_in_testnet_modal()
+
+    with step('Add watched address with plus action button'):
+        wallet = main_screen.left_panel.open_wallet()
+        SigningPhrasePopup().wait_until_appears().confirm_phrase()
+        account_popup = wallet.left_panel.open_add_account_popup()
+        account_popup.set_name(name).set_origin_watched_address(address).save()
+        account_popup.wait_until_hidden()
+
+    with step(
+            'Sort assets by asset balance value and verify the value in combobox is correct and the order is correct'):
+        wallet_account_view = WalletAccountView()
+        sorting = wallet_account_view.open_assets_tab().click_filter_button()
+        sorting.choose_sort_by_value('Asset balance value')
+        wallet_account_view.click_arrow_button('arrow-up-icon', 1)
+        assert wallet_account_view.get_combobox_value() == 'Asset balance value ↑'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == eth, 6000)
+
+        wallet_account_view.click_arrow_button('arrow-down-icon', 1)
+        assert wallet_account_view.get_combobox_value() == 'Asset balance value ↓'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == eth, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == stt, 6000)
+
+    with step('Sort assets by asset balance and verify the value in combobox is correct and the order is correct'):
+        sorting.choose_sort_by_value('Asset balance')
+        wallet_account_view.click_arrow_button('arrow-up-icon', 2)
+        assert wallet_account_view.get_combobox_value() == 'Asset balance ↑'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == eth, 6000)
+
+        wallet_account_view.click_arrow_button('arrow-down-icon', 2)
+        assert wallet_account_view.get_combobox_value() == 'Asset balance ↓'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == eth, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == stt, 6000)
+
+    with step('Sort assets by asset value and verify the value in combobox is correct and the order is correct'):
+        sorting.choose_sort_by_value('Asset value')
+        wallet_account_view.click_arrow_button('arrow-up-icon', 3)
+        assert wallet_account_view.get_combobox_value() == 'Asset value ↑'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == eth, 6000)
+
+        wallet_account_view.click_arrow_button('arrow-down-icon', 3)
+        assert wallet_account_view.get_combobox_value() == 'Asset value ↓'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == eth, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == weenus, 6000)
+
+    with step(
+            'Sort assets by 1d change: balance value and verify the value in combobox is correct and the order is correct'):
+        sorting.choose_sort_by_value('1d change: balance value')
+        wallet_account_view.click_arrow_button('arrow-up-icon', 4)
+        assert wallet_account_view.get_combobox_value() == '1d change: balance value ↑'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == eth, 6000)
+
+        wallet_account_view.click_arrow_button('arrow-down-icon', 4)
+        assert wallet_account_view.get_combobox_value() == '1d change: balance value ↓'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == eth, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == stt, 6000)
+
+    with step('Sort assets by asset name and verify the value in combobox is correct and the order is correct'):
+        sorting.choose_sort_by_value('Asset name')
+        wallet_account_view.click_arrow_button('arrow-up-icon', 5)
+        assert wallet_account_view.get_combobox_value() == 'Asset name ↑'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == dai, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == eth, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == weenus, 6000)
+
+        wallet_account_view.click_arrow_button('arrow-down-icon', 5)
+        assert wallet_account_view.get_combobox_value() == 'Asset name ↓'
+        assets_order = wallet_account_view.get_list_of_assets()
+        assert driver.waitFor(lambda: assets_order[0].title == weenus, 6000)
+        assert driver.waitFor(lambda: assets_order[1].title == stt, 6000)
+        assert driver.waitFor(lambda: assets_order[2].title == eth, 6000)
+        assert driver.waitFor(lambda: assets_order[3].title == dai, 6000)


### PR DESCRIPTION
Added test for assets sorting

Assets sorting: https://ethstatus.testrail.net/index.php?/cases/view/727223


CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1686/allure/#suites/514ff75bb3f68febb5d77eaf0f4cb4fc/6eeace095ee43dee/

<img width="1512" alt="Screenshot 2024-03-22 at 15 17 47" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/619bbcaf-7e30-4477-b213-11794e962371">
