### PR TITLE
test: fix send asset test and enable other tests

### DIFF
--- a/gui/components/wallet/send_popup.py
+++ b/gui/components/wallet/send_popup.py
@@ -1,4 +1,5 @@
 import allure
+import typing
 
 import driver
 from driver.objects_access import wait_for_template
@@ -28,11 +29,17 @@ class SendPopup(BasePopup):
         self._send_button = Button(names.send_StatusFlatButton)
 
     def _select_asset(self, asset: str):
-        for item in driver.findAllObjects(self._asset_list_item.real_name):
-            if str(getattr(item, 'title', '')) == asset:
-                driver.mouseClick(item)
-            else:
-                raise LookupError(f"Chosen asset didn't appear")
+        assets = self.get_assets_list()
+        for index, item in enumerate(assets):
+            if str(item.title) == asset:
+                QObject(item).click()
+
+    @allure.step('Get chats by chats list')
+    def get_assets_list(self) -> typing.List[str]:
+        assets_list = []
+        for asset in driver.findAllObjects(self._asset_list_item.real_name):
+            assets_list.append(asset)
+        return assets_list
 
     def _open_tab(self, name: str):
         assets_tab = wait_for_template(self._tab_item_template.real_name, name, 'text')
@@ -41,7 +48,6 @@ class SendPopup(BasePopup):
     @allure.step('Send {2} {3} to {1}')
     def send(self, address: str, amount: int, asset: str):
         self._open_tab('Assets')
-        self._search_field.type_text(asset)
         self._select_asset(asset)
         assert driver.waitFor(lambda: self._amount_text_edit.is_visible, timeout_msec=6000)
         self._amount_text_edit.text = str(amount)

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -408,7 +408,7 @@ secondary_StatusButton = {"checkable": False, "container": statusDesktop_mainWin
 # Send Popup
 o_StatusTabBar = {"container": statusDesktop_mainWindow_overlay, "type": "StatusTabBar", "unnamed": 1, "visible": True}
 tab_Status_template = {"container": o_StatusTabBar, "type": "StatusBaseText", "unnamed": 1, "visible": True}
-o_TokenBalancePerChainDelegate_template = {"container": statusDesktop_mainWindow_overlay, "type": "TokenBalancePerChainDelegate", "unnamed": 1, "visible": True}
+o_TokenBalancePerChainDelegate_template = {"container": statusDesktop_mainWindow_overlay, "objectName": "tokenBalancePerChainDelegate", "type": "TokenBalancePerChainDelegate", "visible": True}
 amountInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "amountInput", "type": "TextEdit", "visible": True}
 paste_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
 ens_or_address_TextEdit = {"container": statusDesktop_mainWindow_overlay, "id": "edit", "type": "TextEdit", "unnamed": 1, "visible": True}
@@ -753,7 +753,7 @@ savedAddresses_area = {"container": mainWindow_SavedAddressesView_2, "objectName
 # Wallet Account View
 mainWindow_RightTabView = {"container": statusDesktop_mainWindow, "type": "RightTabView", "unnamed": 1, "visible": True}
 mainWallet_Account_Name = {"container": mainWindow_RightTabView, "objectName": "walletHeaderTitle", "type": "StatusBaseText", "visible": True}
-mainWindow_Send_Button = {"container": mainWindow_StatusWindow, "type": "DisabledTooltipButton", "icon": "send", "visible": True}
+mainWindow_Send_Button = {"container": statusDesktop_mainWindow, "objectName": "walletFooterSendButton", "type": "StatusFlatButton", "visible": True}
 mainWindow_RightTabView = {"container": mainWindow_StatusWindow, "type": "RightTabView", "unnamed": 1, "visible": True}
 filterButton_StatusFlatButton = {"checkable": True, "container": mainWindow_RightTabView, "objectName": "filterButton", "type": "StatusFlatButton", "visible": True}
 cmbTokenOrder_SortOrderComboBox = {"container": mainWindow_RightTabView, "objectName": "cmbTokenOrder", "type": "SortOrderComboBox", "visible": True}

--- a/gui/screens/settings_wallet.py
+++ b/gui/screens/settings_wallet.py
@@ -75,11 +75,6 @@ class WalletSettingsView(QObject):
         self._account_order_button.click()
         return EditAccountOrderSettings().wait_until_appears()
 
-    @allure.step('Open Status account view in wallet settings')
-    def open_status_account_in_settings(self):
-        self._status_account_in_keypair.click()
-        return AccountDetailsView().wait_until_appears()
-
     @allure.step('Get keypair names')
     def get_keypairs_names(self):
         keypair_names = []

--- a/tests/communities/test_communities_categories.py
+++ b/tests/communities/test_communities_categories.py
@@ -82,7 +82,6 @@ def test_create_edit_remove_community_category(main_screen: MainWindow, category
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703274', 'Member role cannot remove category')
 @pytest.mark.case(703272, 703273, 703274)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/14059')
 def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
         community_screen = main_screen.left_panel.select_community('Super community')

--- a/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -23,7 +23,6 @@ pytestmark = marks
     pytest.param('0x7f1502605A2f2Cc01f9f4E7dd55e549954A8cD0C', ''.join(random.choices(string.ascii_letters +
                                                                                       string.digits, k=20)))
 ])
-@pytest.mark.skip(reason='https://github.com/status-im/desktop-qa-automation/issues/385')
 def test_settings_include_in_total_balance(main_screen: MainWindow, name, watched_address):
     with (step('Open wallet on main screen and check the total balance for new account is 0')):
         wallet_main_screen = main_screen.left_panel.open_wallet()

--- a/tests/settings/test_ens_name_purchase.py
+++ b/tests/settings/test_ens_name_purchase.py
@@ -32,7 +32,6 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.case(704597)
 @pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
 @pytest.mark.parametrize('ens_name', [pytest.param(constants.user.ens_user_name)])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/14262')
 def test_ens_name_purchase(keys_screen, main_window, user_account, ens_name):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
+++ b/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
@@ -31,7 +31,6 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.parametrize('receiver_account_address, amount, asset', [
     pytest.param(constants.user.user_account_one.status_address, 0, 'Ether')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/12987")
 def test_wallet_send_0_eth(keys_screen, main_window, user_account, receiver_account_address, amount, asset):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()
@@ -52,7 +51,7 @@ def test_wallet_send_0_eth(keys_screen, main_window, user_account, receiver_acco
 
     with step('Verify that restored account reveals correct status wallet address'):
         wallet_settings = main_window.left_panel.open_settings().left_panel.open_wallet_settings()
-        status_acc_view = wallet_settings.open_status_account_in_settings()
+        status_acc_view = wallet_settings.open_account_in_settings('Account 1', '0')
         address = status_acc_view.get_account_address_value()
         assert address == user_account.status_address, \
             f"Recovered account should have address {user_account.status_address}, but has {address}"
@@ -66,7 +65,7 @@ def test_wallet_send_0_eth(keys_screen, main_window, user_account, receiver_acco
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         assert driver.waitFor(lambda: wallet.left_panel.is_total_balance_visible, configs.timeouts.UI_LOAD_TIMEOUT_SEC)
         f"Total balance is not visible"
-        wallet_account = wallet.left_panel.select_account('Status account')
+        wallet_account = wallet.left_panel.select_account('Account 1')
         send_popup = wallet_account.open_send_popup()
 
     with step('Enter asset, amount and address and click send and verify Mainnet network is shown'):


### PR DESCRIPTION
Fixes https://github.com/status-im/desktop-qa-automation/issues/26
Depends on https://github.com/status-im/status-desktop/pull/14306

- Enable back ens purchase test
- Enable back total balance test
- Enable back community categories test
- Fix and enable back send ether test

I ran the test on the build with the new locator (it is not from nightly job )
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1744/allure/#suites/a549ff0f1f607186f4dd560a40d3c78d/6cf5ff14bb7dcb57/

<img width="1840" alt="Screenshot 2024-04-05 at 16 59 37" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/56b5e927-1b72-4bcf-835b-538bfd6ad0dc">
