### PR TITLE
Chore/fix nightly run fails 11 04

### DIFF
--- a/gui/components/picture_edit_popup.py
+++ b/gui/components/picture_edit_popup.py
@@ -50,3 +50,4 @@ class PictureEditPopup(BasePopup):
                 time.sleep(1)
 
         self._make_picture_button.click()
+        self._make_picture_button.wait_until_hidden()

--- a/gui/screens/settings.py
+++ b/gui/screens/settings.py
@@ -55,6 +55,7 @@ class LeftPanel(QObject):
     @allure.step('Open wallet settings')
     def open_wallet_settings(self) -> 'WalletSettingsView':
         self._open_settings('5-AppMenuItem')
+        assert WalletSettingsView().exists, 'Wallet view was not opened'
         return WalletSettingsView()
 
     @allure.step('Open profile settings')


### PR DESCRIPTION
- Added verification after clicking wallet settings so the test will fail instead of long waiting in case it was not opened
- Added verification that button make my profile picture hidden (step of making profile picture passed, but was not supposed to - https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/309/allure/#suites/c48b221cdcfecf89e1eb75d0b8e79672/96efe58c6761a219/)

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1773/