### PR TITLE
ci: use virtualenv to avoid race conditions

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -70,6 +70,10 @@ pipeline {
     PYTHONPATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/lib/python:${PYTHONPATH}"
     LD_LIBRARY_PATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/python3/lib:${LD_LIBRARY_PATH}"
 
+    /* Avoid race conditions with other builds using virtualenv. */
+    VIRTUAL_ENV = "${WORKSPACE_TMP}/venv"
+    PATH = "${VIRTUAL_ENV}/bin:${PATH}"
+
     TESTRAIL_URL = 'https://ethstatus.testrail.net'
     TESTRAIL_PROJECT_ID = 17
 
@@ -87,7 +91,8 @@ pipeline {
 
     stage('Deps') {
       steps { script {
-        sh 'pip3 install --user -r requirements.txt'
+        sh "python3 -m venv ${VIRTUAL_ENV}"
+        sh 'pip3 install -r requirements.txt'
       } }
     }
 


### PR DESCRIPTION
Desktop QA tests also use Pytest packages and their versions are different, so we can't install them globally, it needs to be done per build using `WORKSPACE_TMP` as destination.

Otherwise you get this due to a race condition:
```
 > a ci-slave-linux,ci-slave-release -o -a 'sudo -u jenkins pip list --user 2>/dev/null | grep "^pytest "' | sort
linux-01.he-eu-hel1.ci.release | CHANGED | rc=0 | (stdout) pytest  7.4.0
linux-02.he-eu-hel1.ci.release | CHANGED | rc=0 | (stdout) pytest  7.4.0
linux-01.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.2.1
linux-02.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.4.0
linux-03.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.4.0
linux-04.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.4.0
linux-05.he-eu-hel1.ci.devel | CHANGED | rc=0 | (stdout) pytest    7.2.1
```

Related to:
* https://github.com/status-im/status-mobile/pull/19637