### PR TITLE
chore: stabilisation for make picture step added and for nft test + s…

### DIFF
--- a/gui/components/picture_edit_popup.py
+++ b/gui/components/picture_edit_popup.py
@@ -22,7 +22,7 @@ class PictureEditPopup(BasePopup):
         self._make_picture_button = Button(names.make_picture_StatusButton)
         self._slider_handler = QObject(names.o_DropShadow)
 
-    @allure.step('Make picture')
+    @allure.step('Set zoom shift for picture and make picture')
     def set_zoom_shift_for_picture(
             self,
             zoom: int = None,
@@ -48,6 +48,15 @@ class PictureEditPopup(BasePopup):
                 driver.mouse.press_and_move(
                     self._view.object, 1, self._view.height, 1, self._view.height - shift.bottom, step=1)
                 time.sleep(1)
+        self.make_picture()
 
+    @allure.step('Make picture')
+    def make_picture(self, attempts: int = 2):
         self._make_picture_button.click()
-        self._make_picture_button.wait_until_hidden()
+        try:
+            self._make_picture_button.wait_until_hidden()
+        except AssertionError as err:
+            if attempts:
+                self.make_picture(attempts - 1)
+            else:
+                raise err

--- a/gui/components/wallet/send_popup.py
+++ b/gui/components/wallet/send_popup.py
@@ -1,6 +1,9 @@
+import time
+
 import allure
 import typing
 
+import configs.timeouts
 import driver
 from driver.objects_access import wait_for_template
 from gui.components.base_popup import BasePopup
@@ -30,11 +33,20 @@ class SendPopup(BasePopup):
         self._send_button = Button(names.send_StatusFlatButton)
 
     @allure.step('Select asset or collectible by name')
-    def _select_asset_or_collectible(self, name: str, tab: str):
+    def _select_asset_or_collectible(self, name: str, tab: str, attempts: int = 2):
+        time.sleep(3)
         assets = self.get_assets_or_collectibles_list(tab)
         for index, item in enumerate(assets):
             if str(item.title) == name:
                 QObject(item).click()
+                break
+        try:
+            return self._ens_address_text_edit.wait_until_appears(timeout_msec=configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+        except AssertionError as err:
+            if attempts:
+                self._select_asset_or_collectible(attempts-1)
+            else:
+                raise err
 
     @allure.step('Get assets or collectibles list')
     def get_assets_or_collectibles_list(self, tab: str) -> typing.List[str]:

--- a/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
+++ b/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
@@ -91,6 +91,7 @@ allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704602',
 @pytest.mark.parametrize('tab, receiver_account_address, amount, collectible', [
     pytest.param('Collectibles', constants.user.user_with_funds.status_address, 1, 'Panda')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14466")
 def test_wallet_send_nft(keys_screen, main_window, user_account, tab, receiver_account_address, amount, collectible):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()


### PR DESCRIPTION
- Stabilised make picture step (it failed several times because after click nothing happened, so I added attempts and checking that make picture button was hidden)
- Stabilised nft test and skipped for now because of bug (will check how it works again when will be removing skip mark)

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1787/