### PR TITLE
Fix syncing test

### DIFF
--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -668,7 +668,7 @@ mainWindow_SyncCodeView = {"container": statusDesktop_mainWindow, "type": "SyncC
 mainWindow_switchTabBar_StatusSwitchTabBar_2 = {"container": statusDesktop_mainWindow, "id": "switchTabBar", "type": "StatusSwitchTabBar", "unnamed": 1, "visible": True}
 switchTabBar_Enter_sync_code_StatusSwitchTabButton = {"checkable": True, "container": mainWindow_switchTabBar_StatusSwitchTabBar_2, "text": "Enter sync code", "type": "StatusSwitchTabButton", "unnamed": 1, "visible": True}
 mainWindow_statusBaseInput_StatusBaseInput = {"container": statusDesktop_mainWindow, "id": "statusBaseInput", "type": "StatusBaseInput", "unnamed": 1, "visible": True}
-mainWindow_Paste_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "pasteButtonStatusButton", "type": "StatusButton", "visible": True}
+mainWindow_Paste_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "syncCodePasteButton", "type": "StatusButton", "visible": True}
 mainWindow_syncingEnterCode_SyncingEnterCode = {"container": mainWindow_StatusWindow, "objectName": "syncingEnterCode", "type": "SyncingEnterCode", "visible": True}
 
 # SyncDevice View

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -140,7 +140,7 @@ class SyncCodeView(OnboardingView):
         return self
 
     @allure.step('Paste sync code')
-    def paste_sync_code(self):
+    def click_paste_button(self):
         self._paste_sync_code_button.click()
 
     @property

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -34,7 +34,7 @@ def sync_screen(main_window) -> SyncCodeView:
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703592', 'Sync device during onboarding')
 @pytest.mark.case(703592)
-# @pytest.mark.critical TODO: fix the locator to use object name for button paste
+@pytest.mark.critical
 def test_sync_device_during_onboarding(multiple_instances):
     user: UserAccount = constants.user_with_random_attributes_1
     main_window = MainWindow()

--- a/tests/onboarding/test_onboarding_syncing.py
+++ b/tests/onboarding/test_onboarding_syncing.py
@@ -71,7 +71,8 @@ def test_sync_device_during_onboarding(multiple_instances):
 
         with step('Paste sync code on second instance and wait until device is synced'):
             sync_start = sync_view.open_enter_sync_code_form()
-            sync_start.paste_sync_code()
+            pyperclip.copy(sync_code)
+            sync_start.click_paste_button()
             sync_device_found = SyncDeviceFoundView()
             assert driver.waitFor(
                 lambda: 'Device found!' in sync_device_found.device_found_notifications, 15000)
@@ -106,9 +107,9 @@ def test_wrong_sync_code(sync_screen, wrong_sync_code):
     with step('Open sync code form'):
         sync_view = sync_screen.open_enter_sync_code_form()
 
-    with step('Paste wrong sync code on second instance and check that error message appears'):
+    with step('Paste wrong sync code and check that error message appears'):
         pyperclip.copy(wrong_sync_code)
-        sync_view.paste_sync_code()
+        sync_view.click_paste_button()
         assert SyncingSettings.SYNC_CODE_IS_WRONG_TEXT.value == sync_view.sync_code_error_message, f'Wrong sync code message did not appear'
 
 


### PR DESCRIPTION
PR for release: https://github.com/status-im/status-desktop/pull/14485

I accidentally used incorrect object name (i renamed in main repo after review and forgot to rename here)
Fixed syncing test to stop if failing in release branch all the time

Tests were ran manually against the build with new object name (no nightly yet , it is building now)
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1789/allure/

<img width="1552" alt="Screenshot 2024-04-18 at 21 50 49" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/345d2e52-3a08-48ea-bd76-f615f28dec89">


