### PR TITLE
chore: enable failing tests to reflect the current picture

### DIFF
--- a/tests/settings/test_ens_name_purchase.py
+++ b/tests/settings/test_ens_name_purchase.py
@@ -32,7 +32,6 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.transaction
 @pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
 @pytest.mark.parametrize('ens_name', [pytest.param(constants.user.ens_user_name)])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14487")
 def test_ens_name_purchase(keys_screen, main_window, user_account, ens_name):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/tests/wallet_main_screen/wallet: assets tab/test_wallet_assets_sorting.py
+++ b/tests/wallet_main_screen/wallet: assets tab/test_wallet_assets_sorting.py
@@ -27,7 +27,6 @@ pytestmark = marks
     pytest.param('0xFf58d746A67C2E42bCC07d6B3F58406E8837E883', 'AssetsCollectibles', 'Dai Stablecoin', 'WEENUS Token',
                  'Status Test Token', 'Ether')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14427")
 def test_wallet_sort_assets(main_screen: MainWindow, address, name, dai, weenus, stt, eth):
     with step('Turn on Testnet mode'):
         networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()

--- a/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
+++ b/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
@@ -93,7 +93,6 @@ allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704602',
 @pytest.mark.parametrize('tab, receiver_account_address, amount, collectible', [
     pytest.param('Collectibles', constants.user.user_with_funds.status_address, 1, 'Panda')
 ])
-@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14466")
 def test_wallet_send_nft(keys_screen, main_window, user_account, tab, receiver_account_address, amount, collectible):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()


### PR DESCRIPTION
Right now more people are interested in nightly runs, so I think we need to stop disabling tests because of known issues in the product, to indicate clearly what is not working currently. 

This is not related to flaky tests that has to be stabilised before being enabled