### PR TITLE
chore: remove colors verification from channels test

### DIFF
--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -47,7 +47,7 @@ class CommunityScreen(QObject):
 
     @allure.step('Verify channel')
     def verify_channel(
-            self, name: str, description: str, emoji, color: str):
+            self, name: str, description: str, emoji):
         with step('Channel is correct in channels list'):
             channel = self.left_panel.get_channel_parameters(name)
             assert channel.name == name
@@ -57,13 +57,11 @@ class CommunityScreen(QObject):
             assert self.tool_bar.channel_description == description
             if emoji is not None:
                 assert self.tool_bar.channel_emoji == emoji
-            assert self.tool_bar.channel_color == color
 
         with step('Verify channel in chat'):
             assert self.chat.channel_name == name
             if emoji is not None:
                 assert self.chat.channel_emoji == emoji
-            assert self.chat.channel_color == color
 
     @allure.step('Create category')
     def create_category(self, name: str, general_checkbox: bool):

--- a/gui/screens/settings_messaging.py
+++ b/gui/screens/settings_messaging.py
@@ -26,7 +26,7 @@ class MessagingSettingsView(QObject):
     @allure.step('Open contacts settings')
     def open_contacts_settings(self) -> 'ContactsSettingsView':
         self._contacts_button.click()
-        return ContactsSettingsView().wait_until_appears()
+        return ContactsSettingsView()
 
 
 class ContactItem:
@@ -106,7 +106,14 @@ class ContactsSettingsView(QObject):
     @property
     @allure.step('Get contact items')
     def contact_items(self) -> typing.List[ContactItem]:
-        return [ContactItem(item) for item in self._contacts_items_list.items]
+        try:
+            contact_items = []
+            for i in range(2):
+                contact_items = [ContactItem(item) for item in self._contacts_items_list.items]
+            if len(contact_items) != 0:
+                return contact_items
+        except LookupError as err:
+            raise err
 
     @property
     @allure.step('Get title of list with sent pending requests')
@@ -181,7 +188,7 @@ class ContactsSettingsView(QObject):
 
     @allure.step('Open verify identity popup')
     def open_more_options_popup(
-            self, contact: str, timeout_sec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC, attempts: int = 2):
+            self, contact: str, timeout_sec: int = configs.timeouts.MESSAGING_TIMEOUT_SEC):
         request = self.find_contact_in_list(contact, timeout_sec)
         request.open_more_options_popup()
         return self

--- a/tests/communities/test_communities.py
+++ b/tests/communities/test_communities.py
@@ -63,8 +63,7 @@ def test_create_community(user_account, main_screen: MainWindow, params):
         community_screen.verify_channel(
             'general',
             'General channel for the community',
-            None,
-            color
+            None
         )
 
     with step('Verify community parameters in community settings view'):

--- a/tests/communities/test_communities_channels.py
+++ b/tests/communities/test_communities_channels.py
@@ -19,7 +19,7 @@ pytestmark = marks
     'channel_name, channel_description, channel_emoji, channel_emoji_image, channel_color, new_channel_name, '
     'new_channel_description, new_channel_emoji',
     [('Channel', 'Description', 'sunglasses', None, '#4360df', 'New-channel', 'New channel description', 'thumbsup')])
-# @pytest.mark.critical TODO: https://github.com/status-im/desktop-qa-automation/issues/535
+# @pytest.mark.critical TODO: https://github.com/status-im/desktop-qa-automation/issues/658
 def test_create_edit_remove_community_channel(main_screen, channel_name, channel_description, channel_emoji, channel_emoji_image,
                                 channel_color, new_channel_name, new_channel_description, new_channel_emoji):
     with step('Create simple community'):
@@ -33,8 +33,7 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
         community_screen.verify_channel(
             'general',
             'General channel for the community',
-            None,
-            channel_color
+            None
         )
 
     with step('Create new channel for recently created community'):
@@ -44,8 +43,7 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
         community_screen.verify_channel(
             channel_name,
             channel_description,
-            channel_emoji_image,
-            channel_color
+            channel_emoji_image
         )
 
     with step('Edit channel'):

--- a/tests/settings/test_settings_back_up_seed.py
+++ b/tests/settings/test_settings_back_up_seed.py
@@ -8,6 +8,8 @@ from gui.components.back_up_your_seed_phrase_banner import BackUpSeedPhraseBanne
 from gui.main_window import MainWindow
 
 pytestmark = marks
+
+
 @pytest.mark.critical
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703001', 'Backup seed phrase')
 @pytest.mark.case(703001)


### PR DESCRIPTION
- remove colors validations. Fixes https://github.com/status-im/desktop-qa-automation/issues/535. NOTE: we need to address https://github.com/status-im/desktop-qa-automation/issues/658 and then bring the test back to critical path
- raise lookup error if contacts list is empty

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1826/allure/#suites/a9b9ce4ef70730fb5814a5009e98b445

<img width="1552" alt="Screenshot 2024-04-30 at 19 25 28" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/28309599-584c-4924-b5a5-addbf1e1d19c">
