### PR TITLE
Chore/stabilise rename keypair for ci and fix social links test

### DIFF
--- a/gui/components/settings/rename_keypair_popup.py
+++ b/gui/components/settings/rename_keypair_popup.py
@@ -2,6 +2,7 @@ import allure
 
 import configs
 import driver
+from driver.objects_access import walk_children
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
 from gui.elements.text_edit import TextEdit
@@ -22,6 +23,9 @@ class RenameKeypairPopup(BasePopup):
 
     @allure.step('Rename keypair')
     def rename_keypair(self, name):
-        self._rename_text_edit.text = name
+        for child in walk_children(self.object):
+            if getattr(child, 'id', '') == 'edit':
+                text_edit = TextEdit(real_name=driver.objectMap.realName(child))
+                text_edit.text = name
         self._save_changes_button.click()
         self.wait_until_hidden()

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -370,7 +370,7 @@ reEncryptionComplete = {"container": statusDesktop_mainWindow_overlay, "objectNa
 socialLink_StatusListItem = {"container": statusDesktop_mainWindow_overlay, "index": 1, "type": "StatusListItem", "unnamed": 1, "visible": True}
 placeholder_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "id": "placeholder", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 social_links_back_StatusBackButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBackButton", "unnamed": 1, "visible": True}
-social_links_add_StatusBackButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "unnamed": 1, "visible": True}
+social_links_add_StatusBackButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "addButton", "type": "StatusButton", "visible": True}
 linksView = {"container": statusDesktop_mainWindow, "id": "linksView", "type": "StatusListView", "unnamed": 1, "visible": True}
 
 # Changes detected popup


### PR DESCRIPTION
Guys, let's merge it, because it's needed for nightly runs

- Stabilised rename keypair test (it's flaky)
- Added object name because test for social links is failing all the time

CI runs:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1921/
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1922/