### PR TITLE
test: link preview tests added

### DIFF
--- a/constants/links.py
+++ b/constants/links.py
@@ -1,0 +1,4 @@
+# Links for link preview tests
+external_link = 'https://github.com/status-im/status-desktop/issues/12018'
+link_to_status_community = 'https://status.app/c/G4IAAMSIuU08Lm3oHzSz695ImidijVBxyoFDGEiSYAvADsk9ZVOKYlT2b-lHStyz1MqqkK2Xa4FwoUiq3LBgWsYI_ht6hWXCyLu0TGAk0dGu8IyQWtDSdIXOQ3hWscLjkTo5Vg5-eyUuV8jOVv7khJ_uTofT_TijN-sB#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9'
+status_user_profile_link = 'https://status.app/u/iwWACgoKCHNxdWlzaGVyAw==#zQ3shvMPZSyaUbjBjaNpNP1bPGsGpQDp59dZ4Gmz7UEy5o791'

--- a/constants/messaging.py
+++ b/constants/messaging.py
@@ -10,3 +10,5 @@ class Messaging(Enum):
     YOU_NEED_TO_BE_A_MEMBER = 'You need to be a member of this group to send messages'
     ID_VERIFICATION_REQUEST_SENT = 'ID verification request sent'
     ID_VERIFICATION_REPLY_SENT = 'ID verification reply sent'
+    SHOW_PREVIEWS_TITLE = 'Show link previews?'
+    SHOW_PREVIEWS_TEXT = 'A preview of your link will be shown here before you send it'

--- a/gui/components/messaging/link_preview_options_popup.py
+++ b/gui/components/messaging/link_preview_options_popup.py
@@ -1,0 +1,32 @@
+import allure
+
+import configs
+from gui.components.base_popup import BasePopup
+from gui.elements.button import Button
+from gui.elements.object import QObject
+from gui.objects_map import names
+
+
+class LinkPreviewOptionsPopup(BasePopup):
+
+    def __init__(self):
+        super().__init__()
+        self._show_for_this_message_item = QObject(names.show_for_this_message_StatusMenuItem)
+        self._always_show_item = QObject(names.always_show_previews_StatusMenuItem)
+        self._never_show_item = QObject(names.never_show_previews_StatusMenuItem)
+
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self._show_for_this_message_item.wait_until_appears(timeout_msec)
+        return self
+
+    @allure.step('Wait until hidden {0}')
+    def wait_until_hidden(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self._show_for_this_message_item.wait_until_hidden(timeout_msec)
+        return self
+
+    @allure.step('Verify all preview items are present')
+    def are_all_options_visible(self):
+        assert self._show_for_this_message_item.is_visible
+        assert self._always_show_item.is_visible
+        assert self._never_show_item.is_visible

--- a/gui/objects_map/messaging_names.py
+++ b/gui/objects_map/messaging_names.py
@@ -80,3 +80,14 @@ edit_inputScrollView_messageInputField_TextArea = {"container": chatMessageViewD
 chatMessageViewDelegate_Save_StatusButton = {"checkable": False, "container": chatLogView_chatMessageViewDelegate_MessageView, "id": "saveBtn", "type": "StatusButton", "unnamed": 1, "visible": True}
 chatMessageViewDelegate_reply_icon_StatusIcon = {"container": chatLogView_chatMessageViewDelegate_MessageView, "objectName": "reply-icon", "type": "StatusIcon", "visible": True}
 mainWindow_replyArea_StatusChatInputReplyArea = {"container": statusDesktop_mainWindow, "id": "replyArea", "type": "StatusChatInputReplyArea", "unnamed": 1, "visible": True}
+
+# Message link preview
+mainWindow_optionsComboBox_ComboBox = {"container": statusDesktop_mainWindow, "id": "optionsComboBox", "type": "ComboBox", "unnamed": 1, "visible": True}
+mainWindow_settingsCard_LinkPreviewSettingsCard = {"container": statusDesktop_mainWindow, "id": "settingsCard", "type": "LinkPreviewSettingsCard", "unnamed": 1, "visible": True}
+mainWindow_closeLinkPreviewButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow, "objectName": "closeLinkPreviewButton", "type": "StatusFlatRoundButton", "visible": True}
+mainWindow_linkPreviewTitleText_StatusBaseText = {"container":  statusDesktop_mainWindow, "objectName": "linkPreviewTitleText", "type": "StatusBaseText", "visible": True}
+mainWindow_linkPreviewSubtitleText_StatusBaseText = {"container": statusDesktop_mainWindow, "objectName": "linkPreviewSubtitleText", "type": "StatusBaseText", "visible": True}
+mainWindow_titleText_StatusBaseText = {"container": statusDesktop_mainWindow, "objectName": "titleText", "type": "StatusBaseText", "visible": True}
+mainWindow_subtitleText_StatusBaseText = {"container": statusDesktop_mainWindow, "objectName": "subtitleText", "type": "StatusBaseText", "visible": True}
+linkPreviewTitle_StatusBaseText = {"container": chatLogView_chatMessageViewDelegate_MessageView, "objectName": "linkPreviewTitle", "type": "StatusBaseText", "visible": True}
+linkPreviewEmojiHash_EmojiHash = {"container": chatLogView_chatMessageViewDelegate_MessageView, "objectName": "linkPreviewEmojiHash", "type": "EmojiHash", "visible": True}

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -472,6 +472,11 @@ statusListView = {"container": statusDesktop_mainWindow_overlay, "type": "Status
 # Rename keypair popup
 save_changes_rename_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "saveRenameKeypairChangesButton", "type": "StatusButton", "visible": True}
 
+# Link preview options popup
+show_for_this_message_StatusMenuItem = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "enabled": True, "text": "Show for this message", "type": "StatusMenuItem", "unnamed": 1, "visible": True}
+always_show_previews_StatusMenuItem = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "enabled": True, "text": "Always show previews", "type": "StatusMenuItem", "unnamed": 1, "visible": True}
+never_show_previews_StatusMenuItem = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "enabled": True, "text": "Never show previews", "type": "StatusMenuItem", "unnamed": 1, "visible": True}
+
 # OS NAMES
 # Open Files Dialog
 chooseAnImageALogo_QQuickWindow = {"title": RegularExpression("Choose.*"), "type": "QQuickWindow", "unnamed": 1, "visible": True}
@@ -511,6 +516,10 @@ settings_StatusFlatButton = {"type": "StatusFlatButton", "unnamed": 1, "visible"
 # Messaging View
 mainWindow_MessagingView = {"container": statusDesktop_mainWindow, "type": "MessagingView", "unnamed": 1, "visible": True}
 contactsListItem_btn_StatusContactRequestsIndicatorListItem = {"container": mainWindow_MessagingView, "objectName": "MessagingView_ContactsListItem_btn", "type": "StatusContactRequestsIndicatorListItem", "visible": True}
+settingsContentBase_ScrollView = {"container": statusDesktop_mainWindow, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
+always_ask_radioButton_StatusRadioButton = {"container": settingsContentBase_ScrollView, "objectName": "MessagingView_AlwaysAsk_RadioButton", "type": "SettingsRadioButton", "visible": True}
+always_show_radioButton_StatusRadioButton = {"container": settingsContentBase_ScrollView, "objectName": "MessagingView_AlwaysShow_RadioButton", "type": "SettingsRadioButton", "visible": True}
+never_show_radioButton_StatusRadioButton = {"container": settingsContentBase_ScrollView, "objectName": "MessagingView_NeverShow_RadioButton", "type": "SettingsRadioButton", "visible": True}
 
 # Contacts View
 mainWindow_ContactsView = {"container": statusDesktop_mainWindow, "type": "ContactsView", "unnamed": 1, "visible": True}

--- a/gui/screens/settings_messaging.py
+++ b/gui/screens/settings_messaging.py
@@ -22,11 +22,18 @@ class MessagingSettingsView(QObject):
     def __init__(self):
         super().__init__(names.mainWindow_MessagingView)
         self._contacts_button = Button(names.contactsListItem_btn_StatusContactRequestsIndicatorListItem)
+        self._always_ask_button = Button(names.always_ask_radioButton_StatusRadioButton)
+        self._always_show_button = Button(names.always_show_radioButton_StatusRadioButton)
+        self._never_ask_button = Button(names.never_show_radioButton_StatusRadioButton)
 
     @allure.step('Open contacts settings')
     def open_contacts_settings(self) -> 'ContactsSettingsView':
         self._contacts_button.click()
         return ContactsSettingsView()
+
+    @allure.step('Choose always show previews from website links preview options')
+    def click_always_show(self):
+        self._always_show_button.click()
 
 
 class ContactItem:
@@ -101,7 +108,8 @@ class ContactsSettingsView(QObject):
         self._verify_identity_item = QObject(names.verify_Identity_StatusMenuItem)
         self._respond_to_id_request_item = QObject(names.respond_to_ID_Request_StatusMenuItem)
         self._view_profile_item = QObject(names.view_Profile_StatusMenuItem)
-        self._respond_to_id_request_button = Button(names.settingsContentBaseScrollView_Respond_to_ID_Request_StatusFlatButton)
+        self._respond_to_id_request_button = Button(
+            names.settingsContentBaseScrollView_Respond_to_ID_Request_StatusFlatButton)
 
     @property
     @allure.step('Get contact items')

--- a/tests/messages/test_messaging_link_previews.py
+++ b/tests/messages/test_messaging_link_previews.py
@@ -1,0 +1,125 @@
+import allure
+import pytest
+from allure_commons._allure import step
+
+import configs.testpath
+import constants
+import driver
+from constants import UserAccount
+from constants.links import external_link, link_to_status_community, status_user_profile_link
+from constants.messaging import Messaging
+from gui.main_window import MainWindow
+from gui.screens.messages import MessagesScreen, ToolBar
+from tests.settings.settings_messaging import marks
+
+import configs.testpath
+
+pytestmark = marks
+
+
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704596',
+                 'Sending a link for the first time - default setting')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704578', 'Status community link preview bubble')
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704589', 'Status user profile link preview')
+@pytest.mark.case(704596, 704578, 704578)
+@pytest.mark.parametrize('community_name, domain_link, user_name, user_emoji_hash',
+                         [pytest.param('Status', 'status.app', 'squisher',
+                                       '0x04e972b2a794c315e16411fc0930a65bffffe4f885341683f4532fbbd883a447d849ac0be63d6a4f721affa0d0408160974ff831408433972de2c4556ef06d1ae1')
+                          ])
+def test_link_previews(multiple_instances, community_name, domain_link, user_name, user_emoji_hash):
+    user_one: UserAccount = constants.user_with_random_attributes_1
+    user_two: UserAccount = constants.user_with_random_attributes_2
+    main_window = MainWindow()
+    messages_screen = MessagesScreen()
+
+    with multiple_instances(user_data=None) as aut_one, multiple_instances(user_data=None) as aut_two:
+        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
+            for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
+                aut.attach()
+                main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
+                main_window.authorize_user(account)
+                main_window.hide()
+
+        with step(f'User {user_two.name}, get chat key'):
+            aut_two.attach()
+            main_window.prepare()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
+            chat_key = profile_popup.copy_chat_key
+            profile_popup.close()
+            main_window.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            messaging_settings = settings.left_panel.open_messaging_settings()
+            contacts_settings = messaging_settings.open_contacts_settings()
+            contact_request_popup = contacts_settings.open_contact_request_form()
+            contact_request_popup.send(chat_key, f'Hello {user_two.name}')
+
+        with step(f'User {user_two.name}, accept contact request from {user_one.name} via activity center'):
+            aut_two.attach()
+            main_window.prepare()
+            activity_center = ToolBar().open_activity_center()
+            request = activity_center.find_contact_request_in_list(user_one.name, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            activity_center.click_activity_center_button(
+                'Contact requests').accept_contact_request(request)
+
+        with step(f'User {user_two.name} opens 1x1 chat with {user_one.name} and paste external link'):
+            messages_screen.left_panel.click_chat_by_name(user_one.name)
+            message = external_link
+            messages_screen.group_chat.type_message(message)
+
+        with step('Verify text in the link preview bubble'):
+            assert Messaging.SHOW_PREVIEWS_TITLE.value == messages_screen.group_chat.get_show_link_preview_bubble_title()
+            assert Messaging.SHOW_PREVIEWS_TEXT.value == messages_screen.group_chat.get_show_link_preview_bubble_description()
+
+        with step('Click options combobox and verify that there are 3 options'):
+            messages_screen.group_chat.click_options().are_all_options_visible()
+
+        with step('Close link preview options popup and send a message'):
+            messages_screen.group_chat.close_link_preview_popup().confirm_sending_message()
+
+        with step('Verify that message was sent without preview'):
+            sent_message = messages_screen.chat.messages(0)
+            assert sent_message[0].link_preview is None
+
+        with step(f'Paste external link again and verify that there are still 3 options'):
+            messages_screen.group_chat.type_message(message)
+            messages_screen.group_chat.click_options().are_all_options_visible()
+
+        with step('Close link preview options popup and send a message'):
+            messages_screen.group_chat.close_link_preview_popup().confirm_sending_message()
+
+        with step('Change preview settings to always show previews in messaging settings'):
+            main_window.left_panel.open_settings().left_panel.open_messaging_settings().click_always_show()
+            main_window.left_panel.open_messages_screen().left_panel.click_chat_by_name(user_one.name)
+
+        with step(f'Paste link to status community'):
+            message_community = link_to_status_community
+            messages_screen.group_chat.type_message(message_community)
+
+        with step('Verify title and subtitle of preview are correct and close button exists'):
+            assert driver.waitFor(
+                lambda: community_name == messages_screen.group_chat.get_link_preview_bubble_title(),
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            assert driver.waitFor(
+                lambda: domain_link == messages_screen.group_chat.get_link_preview_bubble_description(),
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+
+        with step('Close link preview options popup and send a message'):
+            messages_screen.group_chat.confirm_sending_message()
+
+        with step(f'Paste link to user profile link and send message'):
+            message_user = status_user_profile_link
+            messages_screen.group_chat.type_message(message_user)
+            assert driver.waitFor(
+                lambda: user_name == messages_screen.group_chat.get_link_preview_bubble_title(), 10000)
+            messages_screen.group_chat.confirm_sending_message()
+
+        with step('Verify title and emojihash are correct for link preview of sent message'):
+            sent_message = messages_screen.chat.messages(0)
+            assert driver.waitFor(lambda: sent_message[0].get_link_preview_title() == user_name,
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            assert driver.waitFor(lambda: sent_message[0].link_preview_emoji_hash == user_emoji_hash,
+                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)


### PR DESCRIPTION
Added tests for link previews. Test cases:
https://ethstatus.testrail.net/index.php?/cases/view/704596
https://ethstatus.testrail.net/index.php?/cases/view/704578
https://ethstatus.testrail.net/index.php?/cases/view/704579

Allure report:
<img width="1361" alt="Screenshot 2024-05-21 at 17 51 28" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/f80ba6ff-3ebd-4cd1-b2cf-aed15a344bd9">


CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1924/