### PR TITLE
test: re-importing seed phrase added to existing test

### DIFF
--- a/constants/onboarding.py
+++ b/constants/onboarding.py
@@ -15,6 +15,12 @@ class OnboardingScreensHeaders(Enum):
     YOUR_PROFILE_SCREEN_TITLE = 'Your profile'
 
 
+class KeysExistText(Enum):
+    KEYS_EXIST_TITLE = 'Keys for this account already exist'
+    KEYS_EXIST_TEXT = (
+        "Keys for this account already exist and can't be added again. If you've lost your password, passcode or Keycard, uninstall the app, reinstall and access your keys by entering your seed phrase. In case of Keycard try recovering using PUK or reinstall the app and try login with the Keycard option.")
+
+
 password_strength_elements = namedtuple('Password_Strength_Elements',
                                         ['strength_indicator', 'strength_color', 'strength_messages'])
 very_weak_lower_elements = password_strength_elements('Very weak', '#ff2d55', ['• Lower case'])

--- a/gui/components/onboarding/keys_already_exist_popup.py
+++ b/gui/components/onboarding/keys_already_exist_popup.py
@@ -1,0 +1,33 @@
+import typing
+
+import allure
+
+import configs
+import driver
+from gui.components.base_popup import BasePopup
+from gui.elements.object import QObject
+from gui.elements.text_label import TextLabel
+from gui.objects_map import names
+
+
+class KeysAlreadyExistPopup(BasePopup):
+    def __init__(self):
+        super(KeysAlreadyExistPopup, self).__init__()
+        self._keys_exist_title = QObject(names.headline_StatusTitleSubtitle)
+        self._keys_exist_text = TextLabel(names.keys_exist_StatusBaseText)
+
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self._keys_exist_title.wait_until_appears(timeout_msec)
+        return self
+
+    @allure.step('Get title of key exist popup')
+    def get_key_exist_title(self) -> str:
+        return str(self._keys_exist_title.object.title)
+
+    @allure.step('Get text of key exist popup')
+    def get_text_labels(self) -> typing.List[str]:
+        text_labels = []
+        for item in driver.findAllObjects(self._keys_exist_text.real_name):
+            text_labels.append(str(item.text))
+        return text_labels

--- a/gui/objects_map/names.py
+++ b/gui/objects_map/names.py
@@ -100,6 +100,10 @@ agreeToUse_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainW
 readyToUse_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "desktopBetaReadyCheckBox", "type": "StatusCheckBox", "visible": True}
 i_m_ready_to_use_Status_Desktop_Beta_StatusButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton", "objectName": "desktopBetaStatusButton", "visible": True}
 
+# Keys Exist Popup
+headline_StatusTitleSubtitle = {"container": statusDesktop_mainWindow_overlay, "id": "headline", "type": "StatusTitleSubtitle", "unnamed": 1, "visible": True}
+keys_exist_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1, "visible": True}
+
 """ Communities """
 
 # Create Community Banner
@@ -686,6 +690,7 @@ mainWindow_Import_seed_phrase = {"container": mainWindow_KeysMainView, "id": "bu
 # Import Seed Phrase View
 keysMainView_PrimaryAction_Button = {"container": statusDesktop_mainWindow,
                                      "objectName": "keysMainViewPrimaryActionButton", "type": "StatusButton"}
+mainWindow_iDontHaveOtherDeviceButton_StatusBaseText = {"container": statusDesktop_mainWindow, "objectName": "iDontHaveOtherDeviceButton", "type": "StatusBaseText", "visible": True}
 
 # Seed Phrase Input View
 mainWindow_SeedPhraseInputView = {"container": statusDesktop_mainWindow, "type": "SeedPhraseInputView", "unnamed": 1,
@@ -699,7 +704,7 @@ switchTabBar_24_words_Button = {"container": mainWindow_SeedPhraseInputView, "ob
 mainWindow_statusSeedPhraseInputField_TextEdit = {"container": mainWindow_StatusWindow, "objectName": "enterSeedPhraseInputField", "type": "TextEdit", "visible": True}
 
 mainWindow_Import_StatusButton = {"checkable": False, "container": mainWindow_SeedPhraseInputView,
-                                  "objectName": "seedPhraseViewSubmitButton", "text": "Import", "type": "StatusButton",
+                                  "objectName": "seedPhraseViewSubmitButton", "type": "StatusButton",
                                   "visible": True}
 
 # SyncCode View
@@ -769,6 +774,8 @@ loginView_currentUserNameLabel = {"container": mainWindow_LoginView, "objectName
 loginView_changeAccountBtn = {"container": mainWindow_LoginView, "objectName": "loginChangeAccountButton", "type": "StatusFlatRoundButton"}
 accountsView_accountListPanel = {"container": statusDesktop_mainWindow, "objectName": "LoginView_AccountsRepeater", "type": "Repeater", "visible": True}
 mainWindow_txtPassword_Input = {"container": statusDesktop_mainWindow, "id": "txtPassword", "type": "Input", "unnamed": 1, "visible": True}
+loginView_addNewUserItem_AccountMenuItemPanel = {"container": statusDesktop_mainWindow_overlay, "index": 0, "objectName": "LoginView_addNewUserItem", "type": "AccountMenuItemPanel", "visible": True}
+o_AccountMenuItemPanel = {"container": statusDesktop_mainWindow_overlay, "index": 1, "type": "AccountMenuItemPanel", "unnamed": 1, "visible": True}
 
 # Touch ID Auth View
 mainWindow_TouchIDAuthView = {"container": statusDesktop_mainWindow, "type": "TouchIDAuthView", "unnamed": 1, "visible": True}

--- a/gui/screens/onboarding.py
+++ b/gui/screens/onboarding.py
@@ -12,6 +12,7 @@ import driver
 from constants import ColorCodes
 from driver.objects_access import walk_children
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
+from gui.components.onboarding.keys_already_exist_popup import KeysAlreadyExistPopup
 from gui.components.os.open_file_dialogs import OpenFileDialog
 from gui.components.picture_edit_popup import PictureEditPopup
 from gui.components.splash_screen import SplashScreen
@@ -92,6 +93,11 @@ class KeysView(OnboardingView):
         self._import_seed_phrase_button.click()
         return ImportSeedPhraseView().wait_until_appears()
 
+    @allure.step('Open Enter Seed Phrase view')
+    def open_enter_seed_phrase_view(self) -> 'ImportSeedPhraseView':
+        self._import_seed_phrase_button.click()
+        return SeedPhraseInputView().wait_until_appears()
+
     @allure.step('Go back')
     def back(self) -> WelcomeToStatusView:
         self._back_button.click()
@@ -120,11 +126,17 @@ class SignBySyncingView(OnboardingView):
     def __init__(self):
         super(SignBySyncingView, self).__init__(names.mainWindow_KeysMainView)
         self._scan_or_enter_sync_code_button = Button(names.keysMainView_PrimaryAction_Button)
+        self._i_dont_have_other_device_button = Button(names.mainWindow_iDontHaveOtherDeviceButton_StatusBaseText)
 
     @allure.step('Open sync code view')
     def open_sync_code_view(self):
         self._scan_or_enter_sync_code_button.click()
         return SyncCodeView().wait_until_appears()
+
+    @allure.step('Open keys view')
+    def open_keys_view(self):
+        self._i_dont_have_other_device_button.click()
+        return KeysView().wait_until_appears()
 
 
 class SyncCodeView(OnboardingView):
@@ -235,10 +247,15 @@ class SeedPhraseInputView(OnboardingView):
             else:
                 self._seed_phrase_input_text_edit.text = word
 
-    @allure.step('Click import button')
+    @allure.step('Import seed phrase')
     def import_seed_phrase(self):
         self._import_button.click()
         return YourProfileView().wait_until_appears()
+
+    @allure.step('Click import button')
+    def click_import_seed_phrase_button(self):
+        self._import_button.click()
+        return KeysAlreadyExistPopup().wait_until_appears()
 
 
 class KeycardInitView(OnboardingView):
@@ -590,6 +607,8 @@ class LoginView(QObject):
         self._change_account_button = Button(names.loginView_changeAccountBtn)
         self._accounts_combobox = QObject(names.accountsView_accountListPanel)
         self._password_object = QObject(names.mainWindow_txtPassword_Input)
+        self._add_new_user_item = QObject(names.loginView_addNewUserItem_AccountMenuItemPanel)
+        self._add_existing_user_item = QObject(names.o_AccountMenuItemPanel)
 
     @property
     @allure.step('Get login error message')
@@ -605,6 +624,12 @@ class LoginView(QObject):
 
         self._password_text_edit.text = account.password
         self._arrow_right_button.click()
+
+    @allure.step('Add existing user')
+    def add_existing_status_user(self):
+        self._current_user_name_label.click()
+        self._add_existing_user_item.click()
+        return SignBySyncingView().wait_until_appears()
 
     @allure.step('Select user')
     def select_user_name(self, user_name, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):

--- a/tests/onboarding/test_onboarding_import_seed.py
+++ b/tests/onboarding/test_onboarding_import_seed.py
@@ -27,7 +27,8 @@ def keys_screen(main_window) -> KeysView:
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703040', 'Import: 12 word seed phrase')
-@pytest.mark.case(703040)
+@allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/736372', 'Re-importing seed-phrase')
+@pytest.mark.case(703040, 736372)
 @pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 @pytest.mark.parametrize('autocomplete, default_name', [
     pytest.param(False, 'Account 1'),


### PR DESCRIPTION
I added re-importing seed phrase and verifying keys already exist popup to existing test. 

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1937/

<img width="976" alt="Screenshot 2024-05-27 at 14 22 20" src="https://github.com/status-im/desktop-qa-automation/assets/141633821/47a52285-2c3b-4cbe-935e-3ddb168f92b2">
