### PR TITLE
Add transaction mark and stabilise 1x1 chat test

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -61,7 +61,7 @@ class LeftPanel(QObject):
     @allure.step('Open messages screen')
     def open_messages_screen(self) -> MessagesScreen:
         self._messages_button.click()
-        return MessagesScreen().wait_until_appears()
+        return MessagesScreen()
 
     @allure.step('Open online identifier')
     def open_online_identifier(self, attempts: int = 2) -> OnlineIdentifier:

--- a/gui/objects_map/messaging_names.py
+++ b/gui/objects_map/messaging_names.py
@@ -2,7 +2,7 @@ from gui.objects_map.names import statusDesktop_mainWindow
 
 # Map for messaging screens, views locators
 
-mainWindow_chatView_ChatView = {"container": statusDesktop_mainWindow, "id": "chatView", "type": "ChatView", "unnamed": 1, "visible": True}
+mainWindow_chatView_ChatView = {"container": statusDesktop_mainWindow, "objectName": "chatViewComponent", "type": "ChatView", "visible": True}
 
 # Left Panel
 mainWindow_contactColumnLoader_Loader = {"container": mainWindow_chatView_ChatView, "id": "contactColumnLoader", "type": "Loader", "unnamed": 1, "visible": True}

--- a/tests/communities/test_communities_mint_owner_token.py
+++ b/tests/communities/test_communities_mint_owner_token.py
@@ -29,6 +29,7 @@ def keys_screen(main_window) -> KeysView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727245', 'Mint owner token')
 @pytest.mark.case(727245)
 @pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
+@pytest.mark.transaction
 def test_mint_owner_token(keys_screen, main_window, user_account):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()


### PR DESCRIPTION
Depends on https://github.com/status-im/status-desktop/pull/14953

Motivation:

<img width="793" alt="Screenshot 2024-05-28 at 18 19 27" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/cb17ebd3-6056-4741-9edb-412587464de2">

CI run of a test itself:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1945/
<img width="1840" alt="Screenshot 2024-05-28 at 19 03 16" src="https://github.com/status-im/desktop-qa-automation/assets/82375995/aa3b7d57-490a-413d-83f1-a9d01702d4de">

CI full run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/1948/parameters/ 
**NOTE:** the send wallet test is getting stuck (same in nightly for several weeks already). Thats not an issue with current PR
