### PR TITLE
Skipped tests dependent on issues with rates limits

### DIFF
--- a/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -23,6 +23,8 @@ pytestmark = marks
     pytest.param('0x7f1502605A2f2Cc01f9f4E7dd55e549954A8cD0C', ''.join(random.choices(string.ascii_letters +
                                                                                       string.digits, k=20)))
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_settings_include_in_total_balance(main_screen: MainWindow, name, watched_address):
     with (step('Open wallet on main screen and check the total balance for new account is 0')):
         wallet_main_screen = main_screen.left_panel.open_wallet()

--- a/tests/settings/test_ens_name_purchase.py
+++ b/tests/settings/test_ens_name_purchase.py
@@ -31,6 +31,8 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.transaction
 @pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
 @pytest.mark.parametrize('ens_name', [pytest.param(constants.user.ens_user_name)])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_ens_name_purchase(keys_screen, main_window, user_account, ens_name):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/tests/wallet_main_screen/wallet: assets tab/test_wallet_assets_sorting.py
+++ b/tests/wallet_main_screen/wallet: assets tab/test_wallet_assets_sorting.py
@@ -28,6 +28,8 @@ pytestmark = marks
     pytest.param('0xFf58d746A67C2E42bCC07d6B3F58406E8837E883', 'AssetsCollectibles', 'Dai Stablecoin', 'WEENUS Token',
                  'Status Test Token', 'Ether')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_wallet_sort_assets(main_screen: MainWindow, address, name, dai, weenus, stt, eth):
     with step('Turn on Testnet mode'):
         networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()

--- a/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
+++ b/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send.py
@@ -31,6 +31,8 @@ def keys_screen(main_window) -> KeysView:
     pytest.param(constants.user.user_account_one.status_address, 0, 'Ether', 'Assets')
 ])
 @pytest.mark.timeout(timeout=120)
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_wallet_send_0_eth(keys_screen, main_window, user_account, receiver_account_address, amount, asset, tab):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send_nft.py
+++ b/tests/wallet_main_screen/wallet: footer actions/test_footer_actions_send_nft.py
@@ -31,6 +31,8 @@ def keys_screen(main_window) -> KeysView:
     pytest.param('Collectibles', constants.user.user_with_funds.status_address, 1, 'Panda')
 ])
 @pytest.mark.timeout(timeout=120)
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_wallet_send_nft(keys_screen, main_window, user_account, tab, receiver_account_address, amount, collectible):
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()


### PR DESCRIPTION
As was discussed, we are disabling tests dependant on rates limits issues. Will get back to them later

TODO: 
- monitor linked tickets https://github.com/status-im/status-desktop/issues/14509, https://github.com/status-im/status-desktop/issues/14862
- implement https://github.com/status-im/desktop-qa-automation/issues/385 and try to use it with transactions (tests that are sending something or verifying chart / balance changes)