### PR TITLE
add soft assertion

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,12 @@
 import logging
-from datetime import datetime
-
+import configs
 import os
 import allure
 import pytest
-from PIL import ImageGrab
 
-import configs
+from tests import test_data
+from PIL import ImageGrab
+from datetime import datetime
 from configs.system import IS_LIN
 from fixtures.path import generate_test_info
 from scripts.utils.system_path import SystemPath
@@ -49,12 +49,31 @@ def setup_function_scope(
     # caplog.set_level(configs.LOG_LEVEL)
     yield
 
+def pytest_runtest_setup(item):
+    test_data.test_name = item.name
+
+    test_data.error = []
+    test_data.steps = []
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
     setattr(item, 'rep_' + rep.when, rep)
+
+    if rep.when == 'call':
+        if rep.failed:
+            test_data.error = rep.longreprtext
+        elif rep.outcome == 'passed':
+            if test_data.error:
+                rep.outcome = 'failed'
+                error_text = str()
+                for line in test_data.error:
+                    error_text += f"{line}; \n ---- soft assert ---- \n\n"
+                rep.longrepr = error_text
+    elif rep.failed:
+        test_data.error = rep.longreprtext
+
 
 
 def pytest_exception_interact(node):

--- a/gui/screens/community.py
+++ b/gui/screens/community.py
@@ -280,10 +280,6 @@ class LeftPanel(QObject):
     def is_add_channels_button_visible(self) -> bool:
         return self._add_channels_button.is_visible
 
-    @allure.step('Get visibility state of add category button')
-    def is_add_category_button_visible(self) -> bool:
-        return self._create_category_button.is_visible
-
     @allure.step('Select channel')
     def select_channel(self, name: str):
         for obj in driver.findAllObjects(self._channel_list_item.real_name):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+class TestData:
+
+    def __init__(self):
+
+        self.test_name = None
+        self.steps = []
+        self.error = []
+
+
+test_data = TestData()

--- a/tests/communities/test_communities_categories.py
+++ b/tests/communities/test_communities_categories.py
@@ -1,9 +1,10 @@
 import allure
 import pytest
-from allure_commons._allure import step
-
 import configs
 import constants
+
+from allure_commons._allure import step
+from tests import test_data
 from gui.components.context_menu import ContextMenu
 from gui.main_window import MainWindow
 from . import marks
@@ -90,10 +91,10 @@ def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow)
         community_screen = main_screen.left_panel.select_community('Super community')
 
     with step('Verify that member cannot add category'):
-        with step('Verify that create channel or category button is not present'):
-            assert not community_screen.left_panel.does_create_channel_or_category_button_exist()
-        with step('Verify that add category button is not present'):
-            assert not community_screen.left_panel.is_add_category_button_visible()
+        if community_screen.left_panel._channel_or_category_button.exists:
+            test_data.error.append("Create channel or category button is present")
+        if community_screen.left_panel._create_category_button.is_visible:
+            test_data.error.append("Create category button is visible")
 
     with step('Verify that member cannot edit category'):
         with step('Right-click on category in the left navigation bar'):


### PR DESCRIPTION
added soft assertion e.g.
![Screenshot 2024-05-31 at 11 53 57](https://github.com/status-im/desktop-qa-automation/assets/12611990/edd2e36d-5bba-4970-9330-8086d3e3dda9)

a test using the assertion will continue checking for more errors instead of failing on the first assertion

